### PR TITLE
Pull Request

### DIFF
--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -747,6 +747,7 @@ pam_sm_authenticate (pam_handle_t * pamh,
       if (resp->resp == NULL)
 	{
 	  DBG (("conv returned NULL passwd?"));
+	  retval = PAM_AUTH_ERR;
 	  goto done;
 	}
 


### PR DESCRIPTION
Fix big security hole: Authentication succeeded when no password
was given, unless use_first_pass was being used.
This is fatal if pam_yubico is considered 'sufficient' in the PAM
configuration.

Signed-off-by: Nanakos Chrysostomos nanakos@wired-net.gr
