### PR TITLE
Bug fix: PAM_yubico doesn't validate server signature

### DIFF
--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -698,12 +698,6 @@ pam_sm_authenticate (pam_handle_t * pamh,
   if (cfg->client_key)
   {
     ykclient_set_verify_signature (ykc, 1);
-    if (rc != YKCLIENT_OK)
-      {
-        DBG (("ykclient_set_verify_signature() failed (%d): %s", rc, ykclient_strerror (rc)));
-        retval = PAM_AUTHINFO_UNAVAIL;
-        goto done;
-      }
   }
 
   if (cfg->capath)


### PR DESCRIPTION
Fix for bug in pam_yubico.c that means that even if an API key is provided in the PAM configuration file, the yubico client does not validate the server signature.

Without this fix, the PAM module will always accept a server response, no matter what HMAC value is returned.

With this fix, if the server HMAC doesn't match the API key provided, the authentication fails with the error message:
sudo: pam_authenticate: Authentication service cannot retrieve authentication info

This bug is because pam_yubico sets the ykclient API key, but fails to set the variable in ykclient that instructs it to validate the server response.
