### PR TITLE
Fix pam_modutil.h detection on Gentoo.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,8 @@ AC_PROG_LIBTOOL
 AC_CHECK_HEADERS([security/pam_appl.h], [],
   [AC_MSG_ERROR([[PAM header files not found, install libpam-dev.]])])
 AC_CHECK_HEADERS([security/pam_modules.h security/_pam_macros.h security/pam_modutil.h], [], [],
-  [#include <security/pam_appl.h>])
+  [#include <sys/types.h>
+   #include <security/pam_appl.h>])
 
 AC_CHECK_LIB([pam], [pam_start])
 


### PR DESCRIPTION
This is required to compile conftest.c for pam_modutil.h on Gentoo with
  sys-libs/pam-1.1.5
  sys-libs/glibc-2.13-r4
  sys-devel/gcc-4.5.3-r2
