### PR TITLE
Add AM_PROG_AR for automake 1.12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@
 AC_INIT([pam_yubico], [2.11], [yubico-devel@googlegroups.com])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
-AM_INIT_AUTOMAKE([1.10 foreign -Wall -Werror])
+AM_INIT_AUTOMAKE([1.10 foreign -Wall -Werror -Wno-extra-portability])
 AM_SILENT_RULES([yes])
 AM_PROG_CC_C_O
 AC_LIBTOOL_WIN32_DLL


### PR DESCRIPTION
Automake 1.12 complains and errors out: "linking libraries using a non-POSIX archiver requires 'AM_PROG_AR' in 'configure.ac'".

This patch fixes the problem.
