### PR TITLE
Verify the otp_length given by the configuration

### DIFF
--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -781,6 +781,13 @@ pam_sm_authenticate (pam_handle_t * pamh,
 
   parse_cfg (flags, argc, argv, cfg);
 
+  if (cfg->token_id_length > MAX_TOKEN_ID_LEN)
+  {
+    DBG (("configuration error: token_id_length too long. Maximum acceptable value : %d", MAX_TOKEN_ID_LEN));
+    retval = PAM_AUTHINFO_UNAVAIL;
+    goto done;
+  }
+
   retval = pam_get_user (pamh, &user, NULL);
   if (retval != PAM_SUCCESS)
     {


### PR DESCRIPTION
Not really a bug, just an error that can be triggered by some bad configuration

Avoid out of bound writing at ligne -920,1 +927,1:
strncpy (otp_id, password + skip_bytes, cfg->token_id_length);
