### PR TITLE
Distinguish 'characters' from 'digits' in README

### DIFF
--- a/README
+++ b/README
@@ -283,7 +283,7 @@ is by using the modhex calculator located here :
 
 http://radius.yubico.com/demo/Modhex_Calculator.php
 
-Enter your Yubikey OTP and convert it, your Yubikey token ID is 12 digits and listed as:
+Enter your Yubikey OTP and convert it, your Yubikey token ID is 12 characters and listed as:
 
    Modhex encoded: XXXXXXX
 


### PR DESCRIPTION
The Yubikey token ID is 12 characters long, not 12 digits long. This 
can make it slightly confusing when first setting a key up, and in 
any case it's incorrect language.
