### PR TITLE
util.c version check fix

### DIFF
--- a/util.c
+++ b/util.c
@@ -119,7 +119,8 @@ check_firmware_version(YK_KEY *yk, bool verbose, bool quiet)
 	}
 
 	if (ykds_version_major(st) < 2 ||
-	    ykds_version_minor(st) < 2) {
+	    (ykds_version_major(st) == 2
+         && ykds_version_minor(st) < 2)) {
 		if (! quiet)
 			fprintf(stderr, "Challenge-response not supported before YubiKey 2.2.\n");
 		free(st);


### PR DESCRIPTION
Without this change, the version check in util.c fails for my new NEO key:

Mac-OSX:~ user$ ./ykpamcfg -v2
Firmware version 3.0.2
Challenge-response not supported before YubiKey 2.2.
