### PR TITLE
Clarified the notion of id when using the pam_yubico module

### DIFF
--- a/README
+++ b/README
@@ -140,7 +140,7 @@ mappings of Yubikey token IDs to user names.
 
 id:: 
 Your API Client ID in the Yubico validation server.
-If you want to the default YubiCloud service, 
+If you want to use the default YubiCloud service, 
 go https://upgrade.yubico.com/getapikey[here].
 
 key::

--- a/README
+++ b/README
@@ -119,7 +119,7 @@ Install it in your PAM setup by adding a line to an appropriate file
 in `/etc/pam.d/`:
 
 ----
-auth sufficient pam_yubico.so id=16 debug
+auth sufficient pam_yubico.so id=[Your API Client ID] debug
 ----
 
 and move pam_yubico.so into /lib/security/ (or wherever PAM modules
@@ -138,7 +138,10 @@ authfile::
 To indicate the location of the file that holds the
 mappings of Yubikey token IDs to user names.
 
-id:: To indicate your client identity.
+id:: 
+Your API Client ID in the Yubico validation server.
+If you want to the default YubiCloud service, 
+go https://upgrade.yubico.com/getapikey[here].
 
 key::
 To indicate your client key in base64 format.
@@ -260,7 +263,7 @@ The mappings should look like this, one per line:
 Now add `authfile=/etc/yubikey_mappings` to your PAM configuration line, so it
 looks like:
 
- auth sufficient pam_yubico.so id=16 authfile=/etc/yubikey_mappings
+ auth sufficient pam_yubico.so id=[Your API Client ID] authfile=/etc/yubikey_mappings
 
  
 === Individual authorization mapping by user
@@ -336,14 +339,14 @@ Examples
 If you want to use the YubiKey to authenticate you on Linux console
 logins, add the following to the top of `/etc/pam.d/login`:
 
-   auth sufficient pam_yubico.so id=16 debug
+   auth sufficient pam_yubico.so id=[Your API Client ID] debug
 
 OpenVPN and ActiveDirectory
 ---------------------------
 
 create file '/etc/pam.d/openvpn':
 
-   auth  required  pam_yubico.so ldap_uri=ldap://ldap-srv debug id=19 yubi_attr=pager
+   auth  required  pam_yubico.so ldap_uri=ldap://ldap-srv debug id=[Your API Client ID] yubi_attr=pager
       ldapdn=dc=ad,dc=next-audience,dc=net
       ldap_filter=(&(sAMAccountName=%u)(memberOf=CN=mygroup,OU=DefaultUser,DC=adivser,DC=net))
       ldap_bind_user=bind_user ldap_bind_password=bind_password try_first_pass


### PR DESCRIPTION
Hi,

Just received my yubikey neo-n and tried to install on a vagrant install of ubuntu 14.04. But was really confused by the different notions of id's in the documentation and also the fact that some test id (16 and 19) where used in the documentation. So I clarified the docs on this, hopefully helping others get up to speed quicker in the future.

Thanks for an excellent product!