### PR TITLE
Support comments in authfile

### DIFF
--- a/tests/util_test.c
+++ b/tests/util_test.c
@@ -58,7 +58,9 @@ static void test_check_user_token(void) {
 
   assert(fd != -1);
   handle = fdopen(fd, "w");
+  fprintf(handle, "# This is a comment containing foobar:foobar\n");
   fprintf(handle, "foobar:hhhvhvhdhbid:hnhbhnhbhnhb:\n");
+  fprintf(handle, "# This is a comment in the middle\n");
   fprintf(handle, "kaka:hdhrhbhjhvhu:hihbhdhrhbhj\n");
   fprintf(handle, "bar:hnhbhnhbhnhb\n");
   fclose(handle);

--- a/util.c
+++ b/util.c
@@ -147,6 +147,12 @@ check_user_token (const char *authfile,
       char *saveptr = NULL;
       if (buf[strlen (buf) - 1] == '\n')
 	buf[strlen (buf) - 1] = '\0';
+      if (buf[0] == '#') {
+          /* This is a comment and we may skip it. */
+          if(verbose)
+              D (("Skipping comment line: %s", buf));
+          continue;
+      }
       if(verbose)
 	  D (("Authorization line: %s", buf));
       s_user = strtok_r (buf, ":", &saveptr);


### PR DESCRIPTION
Adds support for comments (indicated by lines starting with '#') in authfiles.