### PR TITLE
Added authgroup= PAM module parameter to specify group (Unix group) m…

### DIFF
--- a/util.c
+++ b/util.c
@@ -510,3 +510,51 @@ char *filter_printf(const char *filter, const char *user) {
   filter_result_len(filter, user, result);
   return result;
 }
+
+int CheckGroup(char *username, char *group) {
+    
+    int j, ngroups;
+    gid_t *groups;
+    struct passwd *pw;
+    struct group *gr;
+    
+    ngroups = 150;
+    
+    groups = malloc(ngroups * sizeof (gid_t));
+    if (groups == NULL) {
+        perror("malloc");
+        exit(EXIT_FAILURE);
+    }
+    
+    pw = getpwnam(username);
+    if (pw == NULL) {
+        perror("getpwnam");
+        exit(EXIT_SUCCESS);
+    }
+    
+    if (getgrouplist(username, pw->pw_gid, groups, &ngroups) == -1) {
+        exit(EXIT_FAILURE);
+    }
+    
+    for (j = 0; j < ngroups; j++) {
+        gr = getgrgid(groups[j]);
+        if (gr != NULL) {
+            int comparison = strcmp(gr->gr_name, group);
+            if (comparison == 0) {
+                // It's here... Return a 0 and clean up.
+                free(groups);
+                return 0;
+            } else {
+                // Not here... Move on to the next iteration.
+                continue;
+            }
+            
+        }
+    }
+    
+    // Group not found... Clean up and return 1
+    free (groups);
+    return 1;
+    
+}
+

--- a/util.h
+++ b/util.h
@@ -36,6 +36,9 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <grp.h>
+#include <pwd.h>
+#include <string.h>
 
 #if defined(DEBUG_PAM)
 # if defined(HAVE_SECURITY__PAM_MACROS_H)
@@ -43,10 +46,10 @@
 #  include <security/_pam_macros.h>
 # else
 #  define D(x) do {							\
-    printf ("debug: %s:%d (%s): ", __FILE__, __LINE__, __FUNCTION__);	\
-    printf x;								\
-    printf ("\n");							\
-  } while (0)
+printf ("debug: %s:%d (%s): ", __FILE__, __LINE__, __FUNCTION__);	\
+printf x;								\
+printf ("\n");							\
+} while (0)
 # endif /* HAVE_SECURITY__PAM_MACROS_H */
 #else
 # define D(x)
@@ -68,14 +71,14 @@ int check_user_token(const char *authfile, const char *username, const char *otp
 #define CR_DEFAULT_ITERATIONS 10000
 
 struct chalresp_state {
-  char challenge[CR_CHALLENGE_SIZE];
-  uint8_t challenge_len;
-  char response[CR_RESPONSE_SIZE];
-  uint8_t response_len;
-  char salt[CR_SALT_SIZE];
-  uint8_t salt_len;
-  uint8_t slot;
-  uint32_t iterations;
+    char challenge[CR_CHALLENGE_SIZE];
+    uint8_t challenge_len;
+    char response[CR_RESPONSE_SIZE];
+    uint8_t response_len;
+    char salt[CR_SALT_SIZE];
+    uint8_t salt_len;
+    uint8_t slot;
+    uint32_t iterations;
 };
 
 typedef struct chalresp_state CR_STATE;
@@ -90,13 +93,15 @@ int write_chalresp_state(FILE *f, CR_STATE *state);
 int init_yubikey(YK_KEY **yk);
 int check_firmware_version(YK_KEY *yk, bool verbose, bool quiet);
 int challenge_response(YK_KEY *yk, int slot,
-		       char *challenge, unsigned int len,
-		       bool hmac, bool may_block, bool verbose,
-		       char *response, unsigned int res_size, unsigned int *res_len);
+                       char *challenge, unsigned int len,
+                       bool hmac, bool may_block, bool verbose,
+                       char *response, unsigned int res_size, unsigned int *res_len);
 
 #endif /* HAVE_CR */
 
 size_t filter_result_len(const char *filter, const char *user, char *output);
 char *filter_printf(const char *filter, const char *user);
+
+int CheckGroup(char *username, char *group);
 
 #endif /* __PAM_YUBICO_UTIL_H_INCLUDED__ */


### PR DESCRIPTION
Added authgroup= PAM module parameter to specify group (Unix group) members that require a key should be in. This is for use with challenge-response mode.