### PR TITLE
Possibility to remove write access for everyone on chalresp_path's dir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,7 +37,7 @@ libdir = $(PAMDIR)
 
 lib_LTLIBRARIES = pam_yubico.la
 
-pam_yubico_la_SOURCES = drop_privs.h drop_privs.c
+pam_yubico_la_SOURCES = drop_privs.h drop_privs.c groups.h groups.c
 # XXX add -Wl,-x too?  PAM documentation suggests it.
 pam_yubico_la_LIBADD = @LTLIBYUBIKEY@ @LTLIBYKCLIENT@ @LIBLDAP@ @LIBPAM@
 pam_yubico_la_LIBADD += libpam_util.la libpam_real.la

--- a/groups.c
+++ b/groups.c
@@ -1,0 +1,143 @@
+#include <stdlib.h>
+#include <unistd.h>
+#include <limits.h>
+#include <errno.h>
+#include <string.h>
+#include <grp.h>
+
+#include "util.h"
+#include "groups.h"
+
+#define ERR(X) D(X);
+#define WARN(X) if (verbose) { D(x); }
+#define INFO(x) if (verbose) { D(x); }
+
+
+#define DEFAULT_SUPLEMENTARY_GROUPS (15)
+
+#ifdef _SC_NGROUPS_MAX
+int get_max_groups()
+{
+	const long max = sysconf(_SC_NGROUPS_MAX);
+	if (max <= INT_MAX)
+		return (int)max;
+	return INT_MAX;
+}
+#else
+int get_max_groups()
+{
+	return NGROUPS_MAX;
+}
+#endif
+
+#ifndef HAVE_GROUP_MEMBER
+static int group_member(const gid_t gid)
+{
+	const int max = getgroups(0, NULL);
+	int found = 0;
+
+	if (max < 0)
+	{
+		ERR(("Can not get current groups quantity: %s", strerror(errno)));
+		goto out;
+	}
+
+	if (0 == max)
+		goto out;
+
+	gid_t *groups = malloc(sizeof(gid_t)*max);
+	if (groups == NULL)
+	{
+		ERR(("Can not allocate memory for groups: %s", strerror(errno)));
+		goto out;
+	}
+
+	const int num = getgroups(max, groups);
+	if (num < 0)
+	{
+		ERR(("Can not get current groups list: %s", strerror(errno)));
+		goto out;
+	}
+
+	for (int i =0; i < num; ++i)
+	{
+		if (gid == groups[i])
+		{
+			found = 1;
+			break;
+		}
+	}
+
+out:
+	if (NULL != groups)
+		free(groups);
+	return found;
+}
+#endif
+
+int set_supplementary_groups(const char *const username, const gid_t gid, const int verbose)
+{
+	// set supplementary groups for user
+	// 	[in] username
+	// 	[in] gid mandatory group for user (it will be not setted)
+	//	Return value
+	//		0  - OK
+	//		-1 - Error
+	INFO(("set_supplementary_groups %s/%d", username, gid));
+
+	gid_t *groups = NULL;
+	int max_groups = DEFAULT_SUPLEMENTARY_GROUPS, num_groups = 0;
+	const int total_groups = get_max_groups();
+
+	do
+	{
+		groups = malloc(sizeof(gid_t)*max_groups);
+		if (groups == NULL)
+		{
+			ERR(("Can not allocate memory for supplementary groups: %s", strerror(errno)));
+			return -1;
+		}
+
+		int cur_groups = max_groups;
+		if (0 <= getgrouplist(username, gid, groups, &cur_groups))
+		{
+			num_groups = cur_groups;
+		}
+		else
+		{
+			max_groups *= 2;
+			max_groups = (max_groups<cur_groups)?cur_groups:max_groups;
+			free(groups);
+		}
+	} while (max_groups < total_groups && 0 == num_groups);
+
+	if (num_groups > 0)
+	{
+		INFO(("groups = %d", num_groups));
+		{
+			initgroups(username, gid);
+			int new_groups = 0;
+			for (int ind = 0; ind < num_groups; ++ind)
+			{
+				if (0 == group_member(groups[ind])) //Need to attach
+					groups[new_groups++] = groups[ind];
+			}
+			num_groups = new_groups;
+		}
+
+		INFO(("need update groups = %d", num_groups));
+
+		if (num_groups >0 && 0 > setgroups(num_groups, groups))
+		{
+			ERR(("Can not set supplementary groups: %s", strerror(errno)));
+            num_groups = -1;
+		}
+	}
+	else if (num_groups < 0)
+	{
+		ERR(("Can not get groups for user %s", username));
+	}
+
+	free(groups);
+	return (num_groups >= 0)?0:-1;
+}

--- a/groups.h
+++ b/groups.h
@@ -1,0 +1,11 @@
+/* Copyright (c) 2015 madRat
+ * All rights reserved.
+ *
+ * GPL/GNU
+ */
+
+#ifndef __GROUPS_H__
+#define __GROUPS_H__
+
+int set_supplementary_groups(const char *const username, const gid_t gid, const int verbose);
+#endif

--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -42,7 +42,9 @@
 #include <string.h>
 #include <pwd.h>
 
+
 #include "util.h"
+#include "groups.h"
 #include "drop_privs.h"
 
 #include <ykclient.h>
@@ -127,11 +129,6 @@ struct cfg
   const char *chalresp_path;
 };
 
-#define DEFAULT_SUPLEMENTARY_GROUPS (15)
-#define MAX_SUPLEMENTARY_GROUPS  (10000)
-
-static int set_supplementary_groups(const char *const username, const gid_t gid);	// not olny main group
-
 #ifdef DBG
 #undef DBG
 #endif
@@ -184,7 +181,7 @@ authorize_user_token (struct cfg *cfg,
 	goto free_out;
       }
 
-      if (set_supplementary_groups(username, p->pw_gid)) {
+      if (set_supplementary_groups(username, p->pw_gid, cfg->debug)) {
        DBG (("could not set supplementary groups"));
 	retval = 0;
 	goto free_out;
@@ -432,58 +429,6 @@ display_error(pam_handle_t *pamh, const char *message) {
 }
 #endif /* HAVE_CR */
 
-#define DEFAULT_SUPLEMENTARY_GROUPS (15)
-#define MAX_SUPLEMENTARY_GROUPS  (10000)
-int set_supplementary_groups(const char *const username, const gid_t gid)
-{
-	// set supplementary groups for user
-	// 	[in] username
-	// 	[in] gid mandatory group for user (it will be not setted)
-	//	Return value
-	//		0  - OK
-	//		-1 - Error
-
-	gid_t *groups = NULL;
-	int max_groups  = DEFAULT_SUPLEMENTARY_GROUPS, num_groups = 0;
-	do
-	{
-		groups = malloc(sizeof(gid_t)*max_groups);
-		if (groups == NULL)
-		{
-			D(("Can not allocate memory for supplementary groups: %s", strerror(errno)));
-			return -1;
-		}
-
-		int cur_groups = max_groups;
-		if (0 <= getgrouplist(username, gid, groups, &cur_groups))
-		{
-			num_groups = cur_groups;
-		}
-		else
-		{
-			max_groups *= 2;
-			max_groups = (max_groups<cur_groups)?cur_groups:max_groups;
-			free(groups);
-		}
-	} while (max_groups < MAX_SUPLEMENTARY_GROUPS && 0 == num_groups);
-
-	if (num_groups > 0)
-	{
-		if (setgroups(num_groups, groups))
-		{
-			D(("set supplementary groups error: %s", strerror(errno)));
-			num_groups = -1;
-		}
-	}
-	else if (num_groups < 0)
-	{
-		D(("Can not get groups for user %s", username));
-	}
-
-	free(groups);
-	return (num_groups>0)?0:-1;
-}
-
 #if HAVE_CR
 static int
 do_challenge_response(pam_handle_t *pamh, struct cfg *cfg, const char *username)
@@ -538,7 +483,7 @@ do_challenge_response(pam_handle_t *pamh, struct cfg *cfg, const char *username)
       goto out;
   }
 
-  if (set_supplementary_groups(username, p->pw_gid)) {
+  if (set_supplementary_groups(username, p->pw_gid, cfg->debug)) {
       DBG (("could not set supplementary groups"));
       goto out;
   }
@@ -651,7 +596,7 @@ do_challenge_response(pam_handle_t *pamh, struct cfg *cfg, const char *username)
       goto out;
   }
 
-  if (set_supplementary_groups(username, p->pw_gid)) {
+  if (set_supplementary_groups(username, p->pw_gid, cfg->debug)) {
       DBG (("could not set supplementary groups"));
       goto out;
   }


### PR DESCRIPTION
I face the issue that i should do a one from
1. Must allow write for everyone to chalresp_path dir (/etc/yu..) 
2. Chalresp_path dir's owner group must be primay group for all yubikey users

Both solution have issues and I pull patch for possibility to work correctly with supplementary groups in pam_yubiko module.

After my modifications

The Chalresp_path's dir owner may be setted as 'root:yubikey_users' with access only for group and all users, who may auth with key should be added to this group (usermod -aG yubikey_users).