### PR TITLE
Add proxy support via Curl

### DIFF
--- a/README
+++ b/README
@@ -188,6 +188,12 @@ specify the path where X509 certificates are stored. This is
 required if 'https' or 'ldaps' are used in 'url' and 'ldap_uri'
 respectively.
 
+proxy::
+specify a proxy to connect to the validation server. Valid schemes are
+socks4://, socks4a://, socks5:// or socks5h://. Socks5h asks the proxy
+to do the dns resolving. If no scheme or port is specified HTTP proxy
+port 1080 will be used.
+
 verbose_otp::
    This argument is used to show the OTP (One-Time Password) when it
    is entered, i.e. to enable terminal echo of entered characters.

--- a/pam_yubico.8.txt
+++ b/pam_yubico.8.txt
@@ -50,6 +50,9 @@ This option should not be used, please use the urllist option instead.  Set the 
 *capath*=_path_::
 Specify the path where X509 certificates are stored. This is required if 'https' or 'ldaps' are used in 'url' and 'ldap_uri' respectively.
 
+*proxy*=_proxy_::
+Specify a proxy to connect to the validation server. Valid schemes are socks4://, socks4a://, socks5:// or socks5h://. Socks5h asks the proxy to do the dns resolving. If no scheme or port is specified HTTP proxy port 1080 will be used. E.g. socks5h://user:pass@10.10.0.1:1080
+
 *verbose_otp*::
 This argument is used to show the OTP (One Time Password) when it is entered, i.e. to enable terminal echo of entered characters.  You are advised to not use this, if you are using two factor authentication because that will display your password on the screen.  This requires the service using the PAM module to display custom fields.  For example, OpenSSH requires you to configure "ChallengeResponseAuthentication no".
 

--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -111,6 +111,7 @@ struct cfg
   const char *auth_file;
   const char *capath;
   const char *cainfo;
+  const char *proxy;
   const char *url;
   const char *urllist;
   const char *ldapserver;
@@ -710,6 +711,8 @@ parse_cfg (int flags, int argc, const char **argv, struct cfg *cfg)
 	cfg->capath = argv[i] + 7;
       if (strncmp (argv[i], "cainfo=", 7) == 0)
         cfg->cainfo = argv[i] + 7;
+      if (strncmp (argv[i], "proxy=", 6) == 0)
+	cfg->proxy = argv[i] + 6;
       if (strncmp (argv[i], "url=", 4) == 0)
 	cfg->url = argv[i] + 4;
       if (strncmp (argv[i], "urllist=", 8) == 0)
@@ -772,6 +775,7 @@ parse_cfg (int flags, int argc, const char **argv, struct cfg *cfg)
       D (("urllist=%s", cfg->urllist ? cfg->urllist : "(null)"));
       D (("capath=%s", cfg->capath ? cfg->capath : "(null)"));
       D (("cainfo=%s", cfg->cainfo ? cfg->cainfo : "(null)"));
+      D (("proxy=%s", cfg->proxy ? cfg->proxy : "(null)"));
       D (("token_id_length=%d", cfg->token_id_length));
       D (("mode=%s", cfg->mode == CLIENT ? "client" : "chresp" ));
       D (("chalresp_path=%s", cfg->chalresp_path ? cfg->chalresp_path : "(null)"));
@@ -882,6 +886,9 @@ pam_sm_authenticate (pam_handle_t * pamh,
 
   if (cfg->cainfo)
     ykclient_set_ca_info (ykc, cfg->cainfo);
+
+  if (cfg->proxy)
+    ykclient_set_proxy (ykc, cfg->proxy);
 
   if (cfg->url)
     {

--- a/tests/aux/build-and-test.sh
+++ b/tests/aux/build-and-test.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-set -e
 set -x
 
 autoreconf -i
@@ -10,6 +9,7 @@ if [ "x$TRAVIS_OS_NAME" != "xosx" ]; then
     sudo apt-get update -qq || true
     sudo apt-get install -qq -y --no-install-recommends libykclient-dev libpam0g-dev libyubikey-dev asciidoc docbook-xml xsltproc libxml2-utils $EXTRA
 else
+    brew update
     brew install pkg-config
     brew install libtool
     brew install asciidoc
@@ -18,6 +18,8 @@ else
     brew install ykpers
     cpanp install Net::LDAP::Server
 fi
+
+set -e
 
 ./configure $CONFIGURE_ARGS $COVERAGE
 make check


### PR DESCRIPTION
Hello,

Here is the patch to enable proxy support.

Example usage: `auth required pam_yubico.so proxy=socks5h://user:pass@10.10.0.1:1080`

Valid Curl schemes are: socks4://, socks4a://, socks5:// or socks5h:// (the last one to enable socks5 and asking the proxy to do the dns resolving). If no scheme or port is specified HTTP proxy port 1080 will be used per Curl defaults. 

Please note this patch depends on `ykclient_set_proxy` function in my recent contribution to Yubico/yubico-c-client#35

Thanks.