### PR TITLE
Added authgroup= PAM configuration option…

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,3 +42,8 @@ Drop permissions before opening user files.
 
 Fredrik Thulin <fredrik@yubico.com>
 Maintainer alumni, helped on drop_privs.c, utils.c, and more.
+
+Jonathan "JonnyWhatshisface" Hall <jhall@futuresouth.us>
+Added groupauth PAM option
+Added ability to specify groupauth in challenge-response
+

--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -452,7 +452,7 @@ do_challenge_response(pam_handle_t *pamh, struct cfg *cfg, const char *username)
   struct stat st;
     
   if(cfg->auth_group) {
-    result = do_check_group((char*)username,(char*)cfg->auth_group);
+    result = check_user_group((char*)username,(char*)cfg->auth_group);
     
     if(result == 1) {
       errstr = NULL;

--- a/util.c
+++ b/util.c
@@ -227,6 +227,28 @@ check_firmware_version(YK_KEY *yk, bool verbose, bool quiet)
 }
 
 int
+do_check_group(char *username, char *group)
+{
+  struct group *group_ptr;
+  char **group_member;
+  
+  if((group_ptr = getgrnam(group)) == NULL) {
+    // Group was not found... Return a fail
+    D(("Group %s does not exist... Skipping group verification and returning valid!\n",group));
+    return 1;
+  }
+  
+  for (group_member = group_ptr->gr_mem; *group_member != NULL; group_member++) {
+    if(strcmp(*group_member,username) == 0) {
+      // We found the user...
+      D(("User: %s is part of the Group: %s\n", username,group));
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int
 init_yubikey(YK_KEY **yk)
 {
 	if (!yk_init())

--- a/util.c
+++ b/util.c
@@ -1,10 +1,7 @@
-/*
- * Copyright (c) 2011-2014 Yubico AB
+/* Written by Simon Josefsson <simon@yubico.com>.
+ * Copyright (c) 2006-2014 Yubico AB
  * Copyright (c) 2011 Tollef Fog Heen <tfheen@err.no>
  * All rights reserved.
- *
- * Author : Fredrik Thulin <fredrik@yubico.com>
- * Author : Tollef Fog Heen <tfheen@err.no>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -33,496 +30,1173 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
+#include <stdarg.h>
+#include <ctype.h>
+#include <syslog.h>
+
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <errno.h>
+#include <string.h>
 
 #include "util.h"
+#include "drop_privs.h"
+
+#include <ykclient.h>
 
 #if HAVE_CR
-/* for yubikey_hex_decode and yubikey_hex_p */
+/* for yubikey_hex_encode */
 #include <yubikey.h>
+/* for yubikey pbkdf2*/
 #include <ykpbkdf2.h>
-
-#include <ykstatus.h>
-#include <ykdef.h>
 #endif /* HAVE_CR */
 
-int
-get_user_cfgfile_path(const char *common_path, const char *filename, const struct passwd *user, char **fn)
+/* Libtool defines PIC for shared objects */
+#ifndef PIC
+#define PAM_STATIC
+#endif
+
+/* These #defines must be present according to PAM documentation. */
+#define PAM_SM_AUTH
+
+#ifdef HAVE_SECURITY_PAM_APPL_H
+#include <security/pam_appl.h>
+#endif
+#ifdef HAVE_SECURITY_PAM_MODULES_H
+#include <security/pam_modules.h>
+#endif
+
+#ifdef HAVE_LIBLDAP
+/* Some functions like ldap_init, ldap_simple_bind_s, ldap_unbind are
+   deprecated but still available. We will drop support for 'ldapserver'
+   (in favour of 'ldap_uri' and update to using the new functions instead
+   soon.
+*/
+#define LDAP_DEPRECATED 1
+
+#include <ldap.h>
+#define PORT_NUMBER  LDAP_PORT
+#endif
+
+#ifndef PAM_EXTERN
+#ifdef PAM_STATIC
+#define PAM_EXTERN static
+#else
+#define PAM_EXTERN extern
+#endif
+#endif
+
+#define TOKEN_OTP_LEN 32u
+#define MAX_TOKEN_ID_LEN 16u
+#define DEFAULT_TOKEN_ID_LEN 12u
+
+#define TMPFILE_SUFFIX ".XXXXXX"
+
+enum key_mode {
+  CHRESP,
+  CLIENT
+};
+
+struct cfg
 {
-  /* Getting file from user home directory, e.g. ~/.yubico/challenge, or
-   * from a system wide directory.
-   *
-   * Format is hex(challenge):hex(response):slot num
-   */
-  char *userfile;
-  size_t len;
+  unsigned int client_id;
+  const char *client_key;
+  int debug;
+  int alwaysok;
+  int verbose_otp;
+  int try_first_pass;
+  int use_first_pass;
+  const char *auth_file;
+  const char *auth_group;
+  const char *capath;
+  const char *cainfo;
+  const char *proxy;
+  const char *url;
+  const char *urllist;
+  const char *ldapserver;
+  const char *ldap_uri;
+  const char *ldap_bind_user;
+  const char *ldap_bind_password;
+  const char *ldap_filter;
+  const char *ldap_cacertfile;
+  const char *ldapdn;
+  const char *user_attr;
+  const char *yubi_attr;
+  const char *yubi_attr_prefix;
+  unsigned int token_id_length;
+  enum key_mode mode;
+  const char *chalresp_path;
+};
 
-  if (common_path != NULL) {
-    len = strlen(common_path) + 1 + strlen(filename) + 1;
-    if ((userfile = malloc(len)) == NULL) {
-      return 0;
-    }
-    snprintf(userfile, len, "%s/%s", common_path, filename);
-    *fn = userfile;
-    return 1;
-  }
-
-  /* No common path provided. Construct path to user's ~/.yubico/filename */
-
-  len = strlen(user->pw_dir) + 9 + strlen(filename) + 1;
-  if ((userfile = malloc(len)) == NULL) {
-    return 0;
-  }
-  snprintf(userfile, len, "%s/.yubico/%s", user->pw_dir, filename);
-  *fn = userfile;
-  return 1;
-}
-
+#ifdef DBG
+#undef DBG
+#endif
+#define DBG(x) if (cfg->debug) { D(x); }
 
 /*
- * This function will look for users name with valid user token id. It
- * will returns -2 if the user is unknown, -1 if the token do not match the user line, 0 for internal failure and 1 for success.
- *
- * File format is as follows:
- * <user-name>:<token_id>:<token_id>
- * <user-name>:<token_id>
- *
+ * Authorize authenticated OTP_ID for login as USERNAME using
+ * AUTHFILE.  Return -2 if the user is unknown, -1 if the OTP_ID does not match,  0 on internal failures, otherwise success.
  */
-int
-check_user_token (const char *authfile,
-		  const char *username,
-		  const char *otp_id,
-		  int verbose)
+static int
+authorize_user_token (struct cfg *cfg,
+		      const char *username,
+		      const char *otp_id,
+		      pam_handle_t *pamh)
 {
-  char buf[1024];
-  char *s_user, *s_token;
-  int retval = 0;
-  int fd;
-  struct stat st;
-  FILE *opwfile;
+  int retval;
 
-  fd = open(authfile, O_RDONLY, 0);
-  if (fd < 0) {
-      if(verbose)
-	  D (("Cannot open file: %s (%s)", authfile, strerror(errno)));
-      return retval;
-  }
-
-  if (fstat(fd, &st) < 0) {
-      if(verbose)
-	  D (("Cannot stat file: %s (%s)", authfile, strerror(errno)));
-      close(fd);
-      return retval;
-  }
-
-  if (!S_ISREG(st.st_mode)) {
-      if(verbose)
-	  D (("%s is not a regular file", authfile));
-      close(fd);
-      return retval;
-  }
-
-  opwfile = fdopen(fd, "r");
-  if (opwfile == NULL) {
-      if(verbose)
-	  D (("fdopen: %s", strerror(errno)));
-      close(fd);
-      return retval;
-  }
-
-  retval = -2;
-  while (fgets (buf, 1024, opwfile))
+  if (cfg->auth_file)
     {
-      char *saveptr = NULL;
-      if (buf[strlen (buf) - 1] == '\n')
-	buf[strlen (buf) - 1] = '\0';
-      if (buf[0] == '#') {
-          /* This is a comment and we may skip it. */
-          if(verbose)
-              D (("Skipping comment line: %s", buf));
-          continue;
-      }
-      if(verbose)
-	  D (("Authorization line: %s", buf));
-      s_user = strtok_r (buf, ":", &saveptr);
-      if (s_user && strcmp (username, s_user) == 0)
-	{
-	  if(verbose)
-	      D (("Matched user: %s", s_user));
-      retval = -1; //We found at least one line for the user
-	  do
-	    {
-	      s_token = strtok_r (NULL, ":", &saveptr);
-	      if(verbose)
-		  D (("Authorization token: %s", s_token));
-	      if (s_token && strcmp (otp_id, s_token) == 0)
-		{
-		  if(verbose)
-		      D (("Match user/token as %s/%s", username, otp_id));
-		  fclose (opwfile);
-		  return 1;
-		}
-	    }
-	  while (s_token != NULL);
-	}
+      /* Administrator had configured the file and specified is name
+         as an argument for this module.
+       */
+      DBG (("Using system-wide auth_file %s", cfg->auth_file));
+      retval = check_user_token (cfg->auth_file, username, otp_id, cfg->debug);
     }
+  else
+    {
+      char *userfile = NULL;
+      struct passwd *p;
+      PAM_MODUTIL_DEF_PRIVS(privs);
 
-  fclose (opwfile);
+#ifdef HAVE_PAM_MODUTIL_GETPWNAM
+      p = pam_modutil_getpwnam (pamh, username);
+#else
+      p = getpwnam (username);
+#endif
+      if (p == NULL) {
+	DBG (("getpwnam: %s", strerror(errno)));
+	return 0;
+      }
+
+      /* Getting file from user home directory
+         ..... i.e. ~/.yubico/authorized_yubikeys
+       */
+      if (! get_user_cfgfile_path (NULL, "authorized_yubikeys", p, &userfile)) {
+	D (("Failed figuring out per-user cfgfile"));
+	return 0;
+      }
+
+      DBG (("Dropping privileges"));
+      if(pam_modutil_drop_priv(pamh, &privs, p)) {
+        DBG (("could not drop privileges"));
+	retval = 0;
+	goto free_out;
+      }
+
+      retval = check_user_token (userfile, username, otp_id, cfg->debug);
+
+      if(pam_modutil_regain_priv(pamh, &privs)) {
+        DBG (("could not restore privileges"));
+        retval = 0;
+        goto free_out;
+      }
+
+free_out:
+      free (userfile);
+    }
 
   return retval;
 }
 
+/*
+ * This function will look in ldap id the token correspond to the
+ * requested user. It will returns 0 for failure and 1 for success.
+ *
+ * ldaps is only supported for ldap_uri based connections.
+ * ldap_cacertfile usually needs to be set for this to work.
+ *
+ * ldap serve can be on a remote host.
+ *
+ * You need the following parameters in you pam config:
+ * ldapserver=  OR ldap_uri=
+ * ldapdn=
+ * user_attr=
+ * yubi_attr=
+ *
+ * If using ldap_uri, you can specify multiple failover hosts
+ * eg.
+ * ldap_uri=ldaps://host1.fqdn.example.com,ldaps://host2.fqdn.example.com
+ */
+static int
+authorize_user_token_ldap (struct cfg *cfg,
+			   const char *user,
+			   const char *token_id)
+{
+  int retval = 0;
+#ifdef HAVE_LIBLDAP
+  /* LDAPv2 is historical -- RFC3494. */
+  int protocol = LDAP_VERSION3;
+  size_t yubi_attr_prefix_len = 0;
+  LDAP *ld = NULL;
+  LDAPMessage *result = NULL, *e;
+  BerElement *ber;
+  char *a;
+  char *attrs[2] = {NULL, NULL};
+
+  struct berval **vals;
+  int rc;
+  size_t i;
+
+  char *filter = NULL;
+  char *find = NULL;
+  int scope = LDAP_SCOPE_BASE;
+#endif
+  DBG(("called"));
+#ifdef HAVE_LIBLDAP
+  if (cfg->yubi_attr == NULL) {
+    DBG (("Trying to look up user to YubiKey mapping in LDAP, but yubi_attr not set!"));
+    return 0;
+  }
+  if (cfg->user_attr && cfg->ldapdn == NULL) {
+    DBG (("Trying to look up user to YubiKey mapping in LDAP, user_attr set but ldapdn not set!"));
+    return 0;
+  }
+
+  /* Get a handle to an LDAP connection. */
+  if (cfg->ldap_uri)
+    {
+      rc = ldap_initialize (&ld, cfg->ldap_uri);
+      if (rc != LDAP_SUCCESS)
+	{
+	  DBG (("ldap_initialize: %s", ldap_err2string (rc)));
+	  retval = 0;
+	  goto done;
+	}
+    }
+  else
+    {
+      if ((ld = ldap_init (cfg->ldapserver, PORT_NUMBER)) == NULL)
+	{
+	  DBG (("ldap_init"));
+	  retval = 0;
+	  goto done;
+	}
+    }
+
+  ldap_set_option(ld, LDAP_OPT_REFERRALS, LDAP_OPT_OFF);
+  ldap_set_option (ld, LDAP_OPT_PROTOCOL_VERSION, &protocol);
+
+  if (cfg->ldap_uri && cfg->ldap_cacertfile) {
+    /* Set CA CERTFILE.  This makes ldaps work when using ldap_uri */
+    ldap_set_option (0, LDAP_OPT_X_TLS_CACERTFILE, cfg->ldap_cacertfile);
+  }
+  /* Bind anonymously to the LDAP server. */
+  if (cfg->ldap_bind_user && cfg->ldap_bind_password) {
+    DBG (("try bind with: %s:[%s]", cfg->ldap_bind_user, cfg->ldap_bind_password));
+    rc = ldap_simple_bind_s (ld, cfg->ldap_bind_user, cfg->ldap_bind_password);
+  } else {
+    DBG (("try bind anonymous"));
+    rc = ldap_simple_bind_s (ld, NULL, NULL);
+  }
+  if (rc != LDAP_SUCCESS)
+    {
+      DBG (("ldap_simple_bind_s: %s", ldap_err2string (rc)));
+      retval = 0;
+      goto done;
+    }
+
+  /* Allocation of memory for search strings depending on input size */
+  if (cfg->user_attr && cfg->yubi_attr && cfg->ldapdn) {
+    i = (strlen(cfg->user_attr) + strlen(cfg->ldapdn) + strlen(user) + 3) * sizeof(char);
+    if ((find = malloc(i)) == NULL) {
+      DBG (("Failed allocating %zu bytes", i));
+      retval = 0;
+      goto done;
+    }
+    sprintf (find, "%s=%s,%s", cfg->user_attr, user, cfg->ldapdn);
+    filter = NULL;
+  } else if (cfg->ldapdn) {
+    find = strdup(cfg->ldapdn); /* allow free later */
+  }
+  if (cfg->ldap_filter) {
+    filter = filter_printf(cfg->ldap_filter, user);
+    scope = LDAP_SCOPE_SUBTREE;
+  }
+  attrs[0] = (char *) cfg->yubi_attr;
+
+  DBG(("LDAP : look up object base='%s' filter='%s', ask for attribute '%s'", find,
+      filter ? filter:"(null)", cfg->yubi_attr));
+
+  /* Search for the entry. */
+  if ((rc = ldap_search_ext_s (ld, find, scope,
+			       filter, attrs, 0, NULL, NULL, LDAP_NO_LIMIT,
+			       LDAP_NO_LIMIT, &result)) != LDAP_SUCCESS)
+    {
+      DBG (("ldap_search_ext_s: %s", ldap_err2string (rc)));
+
+      retval = 0;
+      goto done;
+    }
+
+  e = ldap_first_entry (ld, result);
+  if (e == NULL)
+    {
+      DBG (("No result from LDAP search"));
+      retval = -2;
+    }
+  else
+    {
+      retval = -1;
+      /* Iterate through each returned attribute. */
+      for (a = ldap_first_attribute (ld, e, &ber);
+	   a != NULL; a = ldap_next_attribute (ld, e, ber))
+	{
+	  if ((vals = ldap_get_values_len (ld, e, a)) != NULL)
+	    {
+	      yubi_attr_prefix_len = cfg->yubi_attr_prefix ? strlen(cfg->yubi_attr_prefix) : 0;
+
+	      /* Compare each value for the attribute against the token id. */
+	      for (i = 0; vals[i] != NULL; i++)
+		{
+	          DBG(("LDAP : Found %i values - checking if any of them match '%s:%s:%s'",
+		       ldap_count_values_len(vals),
+		       vals[i]->bv_val,
+		       cfg->yubi_attr_prefix ? cfg->yubi_attr_prefix : "", token_id));
+
+		  /* Only values containing this prefix are considered. */
+		  if ((!cfg->yubi_attr_prefix || !strncmp (cfg->yubi_attr_prefix, vals[i]->bv_val, yubi_attr_prefix_len)))
+		    {
+		      if(!strncmp (token_id, vals[i]->bv_val + yubi_attr_prefix_len, strlen (token_id)))
+		        {
+		          DBG (("Token Found :: %s", vals[i]->bv_val));
+		          retval = 1;
+		        }
+		    }
+		}
+	      ldap_value_free_len (vals);
+	    }
+	  ldap_memfree (a);
+	}
+      if (ber != NULL)
+	  ber_free (ber, 0);
+    }
+
+ done:
+  if (result != NULL)
+    ldap_msgfree (result);
+  if (ld != NULL)
+    ldap_unbind (ld);
+
+  /* free memory allocated for search strings */
+  if (find != NULL)
+    free(find);
+  if (filter != NULL)
+    free(filter);
+
+#else
+  DBG (("Trying to use LDAP, but this function is not compiled in pam_yubico!!"));
+  DBG (("Install libldap-dev and then recompile pam_yubico."));
+#endif
+  return retval;
+}
+
 #if HAVE_CR
-/* Fill buf with len bytes of random data */
-int generate_random(void *buf, int len)
-{
-	FILE *u;
-	int res;
+static int
+display_error(pam_handle_t *pamh, const char *message) {
+  struct pam_conv *conv;
+  const struct pam_message *pmsg[1];
+  struct pam_message msg[1];
+  struct pam_response *resp = NULL;
+  int retval;
 
-	u = fopen("/dev/urandom", "r");
-	if (!u) {
-		return -1;
-	}
+  retval = pam_get_item (pamh, PAM_CONV, (const void **) &conv);
+  if (retval != PAM_SUCCESS) {
+    D(("get conv returned error: %s", pam_strerror (pamh, retval)));
+    return retval;
+  }
 
-	res = fread(buf, 1, (size_t) len, u);
-	fclose(u);
-
-	return (res != len);
-}
-
-int
-check_firmware_version(YK_KEY *yk, bool verbose, bool quiet)
-{
-	YK_STATUS *st = ykds_alloc();
-
-	if (!yk_get_status(yk, st)) {
-		free(st);
-		return 0;
-	}
-
-	if (verbose) {
-		D(("YubiKey Firmware version: %d.%d.%d\n",
-		       ykds_version_major(st),
-		       ykds_version_minor(st),
-		       ykds_version_build(st)));
-		fflush(stdout);
-	}
-
-	if (ykds_version_major(st) < 2 ||
-	    (ykds_version_major(st) == 2
-         && ykds_version_minor(st) < 2)) {
-		if (! quiet)
-			fprintf(stderr, "Challenge-response not supported before YubiKey 2.2.\n");
-		free(st);
-		return 0;
-	}
-
-	free(st);
-	return 1;
-}
-
-int
-do_check_group(char *username, char *group)
-{
-  struct group *group_ptr;
-  char **group_member;
+  if(!conv || !conv->conv){
+    D(("conv() function invalid"));
+    return PAM_CONV_ERR;
+  }
+  pmsg[0] = &msg[0];
+  msg[0].msg = (char *) message; /* on some systems, pam_message.msg isn't const */
+  msg[0].msg_style = PAM_ERROR_MSG;
+  retval = conv->conv(1, pmsg, &resp, conv->appdata_ptr);
   
-  if((group_ptr = getgrnam(group)) == NULL) {
-    // Group was not found... Return a fail
-    D(("Group %s does not exist... Skipping group verification and returning valid!\n",group));
-    return 1;
+  if (retval != PAM_SUCCESS) {
+    D(("conv returned error: %s", pam_strerror (pamh, retval)));
+    return retval;
   }
-  
-  for (group_member = group_ptr->gr_mem; *group_member != NULL; group_member++) {
-    if(strcmp(*group_member,username) == 0) {
-      // We found the user...
-      D(("User: %s is part of the Group: %s\n", username,group));
-      return 0;
+
+  if (resp)
+    {
+      D(("conv returned: '%s'", resp->resp));
+      if (resp->resp)
+        free (resp->resp);
+      free (resp);
     }
-  }
-  return 1;
-}
-
-int
-init_yubikey(YK_KEY **yk)
-{
-	if (!yk_init())
-		return 0;
-
-	if (!(*yk = yk_open_first_key()))
-		return 0;
-
-	return 1;
-}
-
-int challenge_response(YK_KEY *yk, int slot,
-		       char *challenge, unsigned int len,
-		       bool hmac, bool may_block, bool verbose,
-		       char *response, unsigned int res_size, unsigned int *res_len)
-{
-	int yk_cmd;
-
-  if(hmac == true) {
-    *res_len = 20;
-  } else {
-    *res_len = 16;
-  }
-	if (res_size < *res_len) {
-	  return 0;
-  }
-
-	memset(response, 0, res_size);
-
-	if (verbose) {
-		fprintf(stderr, "Sending %u bytes %s challenge to slot %i\n", len, (hmac == true)?"HMAC":"Yubico", slot);
-		//_yk_hexdump(challenge, len);
-	}
-
-	switch(slot) {
-	case 1:
-		yk_cmd = (hmac == true) ? SLOT_CHAL_HMAC1 : SLOT_CHAL_OTP1;
-		break;
-	case 2:
-		yk_cmd = (hmac == true) ? SLOT_CHAL_HMAC2 : SLOT_CHAL_OTP2;
-		break;
-	default:
-		return 0;
-	}
-
-  if(! yk_challenge_response(yk, yk_cmd, may_block, len,
-        (unsigned char*)challenge, res_size, (unsigned char*)response)) {
-    return 0;
-  }
-
-
-	return 1;
-}
-
-int
-get_user_challenge_file(YK_KEY *yk, const char *chalresp_path, const struct passwd *user, char **fn)
-{
-  /* Getting file from user home directory, i.e. ~/.yubico/challenge, or
-   * from a system wide directory.
-   */
-
-  /* The challenge to use is located in a file in the user's home directory,
-   * which therefor can't be encrypted. If an encrypted home directory is used,
-   * the option chalresp_path can be used to point to a system-wide directory.
-   */
-
-  const char *filename = NULL; /* not including directory */
-  char *ptr = NULL;
-  unsigned int serial = 0;
-  int ret;
-
-  if (! yk_get_serial(yk, 0, 0, &serial)) {
-    D (("Failed to read serial number (serial-api-visible disabled?)."));
-    if (! chalresp_path)
-      filename = "challenge";
-    else
-      filename = user->pw_name;
-  } else {
-    /* We have serial number */
-    /* 0xffffffff == 4294967295 == 10 digits */
-    size_t len = strlen(chalresp_path == NULL ? "challenge" : user->pw_name) + 1 + 10 + 1;
-    if ((ptr = malloc(len)) != NULL) {
-      int res = snprintf(ptr, len, "%s-%u", chalresp_path == NULL ? "challenge" : user->pw_name, serial);
-      filename = ptr;
-      if (res < 0 || (unsigned long)res > len) {
-	/* Not enough space, strangely enough. */
-	free(ptr);
-	filename = NULL;
-      }
-    }
-  }
-
-  if (filename == NULL)
-    return 0;
-
-  ret = get_user_cfgfile_path (chalresp_path, filename, user, fn);
-  if(ptr) {
-    free(ptr);
-  }
-  return ret;
-}
-
-int
-load_chalresp_state(FILE *f, CR_STATE *state, bool verbose)
-{
-  /*
-   * Load the current challenge and expected response information from a file handle.
-   *
-   * Format is hex(challenge):hex(response):slot num
-   */
-  char challenge_hex[CR_CHALLENGE_SIZE * 2 + 1], response_hex[CR_RESPONSE_SIZE * 2 + 1];
-  char salt_hex[CR_SALT_SIZE * 2 + 1];
-  unsigned int iterations;
-  int slot;
-  int r;
-
-  if (! f)
-    goto out;
-
-  /* XXX not ideal with hard coded lengths in this scan string.
-   * 126 corresponds to twice the size of CR_CHALLENGE_SIZE,
-   * 40 is twice the size of CR_RESPONSE_SIZE
-   * (twice because we hex encode the challenge and response)
-   */
-  r = fscanf(f, "v2:%126[0-9a-z]:%40[0-9a-z]:%64[0-9a-z]:%d:%d", challenge_hex, response_hex, salt_hex, &iterations, &slot);
-  if(r == 5) {
-    if (! yubikey_hex_p(salt_hex)) {
-      D(("Invalid salt hex input : %s", salt_hex));
-      goto out;
-    }
-
-    if(verbose) {
-      D(("Challenge: %s, hashed response: %s, salt: %s, iterations: %d, slot: %d",
-            challenge_hex, response_hex, salt_hex, iterations, slot));
-    }
-
-    yubikey_hex_decode(state->salt, salt_hex, sizeof(state->salt));
-    state->salt_len = strlen(salt_hex) / 2;
-  } else {
-    rewind(f);
-    r = fscanf(f, "v1:%126[0-9a-z]:%40[0-9a-z]:%d", challenge_hex, response_hex, &slot);
-    if (r != 3) {
-      D(("Could not parse contents of chalresp_state file (%i)", r));
-      goto out;
-    }
-
-    if (verbose) {
-      D(("Challenge: %s, expected response: %s, slot: %d", challenge_hex, response_hex, slot));
-    }
-
-    iterations = CR_DEFAULT_ITERATIONS;
-  }
-
-  state->iterations = iterations;
-
-
-  if (! yubikey_hex_p(challenge_hex)) {
-    D(("Invalid challenge hex input : %s", challenge_hex));
-    goto out;
-  }
-
-  if (! yubikey_hex_p(response_hex)) {
-    D(("Invalid expected response hex input : %s", response_hex));
-    goto out;
-  }
-
-  if (slot != 1 && slot != 2) {
-    D(("Invalid slot input : %i", slot));
-    goto out;
-  }
-
-  yubikey_hex_decode(state->challenge, challenge_hex, sizeof(state->challenge));
-  state->challenge_len = strlen(challenge_hex) / 2;
-
-  yubikey_hex_decode(state->response, response_hex, sizeof(state->response));
-  state->response_len = strlen(response_hex) / 2;
-
-  state->slot = slot;
-
-  return 1;
-
- out:
-  return 0;
-}
-
-int
-write_chalresp_state(FILE *f, CR_STATE *state)
-{
-  char challenge_hex[CR_CHALLENGE_SIZE * 2 + 1], response_hex[CR_RESPONSE_SIZE * 2 + 1];
-  char salt_hex[CR_SALT_SIZE * 2 + 1], hashed_hex[CR_RESPONSE_SIZE * 2 + 1];
-  unsigned char salt[CR_SALT_SIZE], hash[CR_RESPONSE_SIZE];
-  YK_PRF_METHOD prf_method = {20, yk_hmac_sha1};
-  unsigned int iterations = CR_DEFAULT_ITERATIONS;
-  int fd;
-
-  memset(challenge_hex, 0, sizeof(challenge_hex));
-  memset(response_hex, 0, sizeof(response_hex));
-  memset(salt_hex, 0, sizeof(salt_hex));
-  memset(hashed_hex, 0, sizeof(hashed_hex));
-
-  yubikey_hex_encode(challenge_hex, (char *)state->challenge, state->challenge_len);
-  yubikey_hex_encode(response_hex, (char *)state->response, state->response_len);
-
-  if(state->iterations > 0) {
-    iterations = state->iterations;
-  }
-
-  generate_random(salt, CR_SALT_SIZE);
-  yk_pbkdf2(response_hex, salt, CR_SALT_SIZE, iterations,
-      hash, CR_RESPONSE_SIZE, &prf_method);
-
-  yubikey_hex_encode(hashed_hex, (char *)hash, CR_RESPONSE_SIZE);
-  yubikey_hex_encode(salt_hex, (char *)salt, CR_SALT_SIZE);
-
-  rewind(f);
-
-  fd = fileno(f);
-  if (fd == -1)
-    goto out;
-
-  if (ftruncate(fd, 0))
-    goto out;
-
-  fprintf(f, "v2:%s:%s:%s:%u:%d\n", challenge_hex, hashed_hex, salt_hex, iterations, state->slot);
-
-  if (fflush(f) < 0)
-    goto out;
-
-  if (fsync(fd) < 0)
-    goto out;
-
-  return 1;
- out:
-  return 0;
+  return retval;
 }
 #endif /* HAVE_CR */
 
-size_t filter_result_len(const char *filter, const char *user, char *output) {
-  const char *part = NULL;
-  size_t result = 0;
-  do
+#if HAVE_CR
+static int
+do_challenge_response(pam_handle_t *pamh, struct cfg *cfg, const char *username)
+{
+  char *userfile = NULL, *tmpfile = NULL;
+  FILE *f = NULL;
+  char buf[CR_RESPONSE_SIZE + 16], response_hex[CR_RESPONSE_SIZE * 2 + 1];
+  int ret, fd, result;
+
+  unsigned int response_len = 0;
+  YK_KEY *yk = NULL;
+  CR_STATE state;
+
+  const char *errstr = NULL;
+
+  struct passwd *p;
+  struct stat st;
+    
+  if(cfg->auth_group) {
+    result = check_user_group((char*)username,(char*)cfg->auth_group);
+    
+    if(result == 1) {
+      errstr = NULL;
+      errno = 0;
+      ret = PAM_SUCCESS;
+      DBG(("User %s is not in group %s - skipping YubiKey requirement for login!", username, cfg->auth_group));
+      goto out;
+    }
+  }
+
+  /* we must declare two sepparate privs structures as they can't be reused */
+  PAM_MODUTIL_DEF_PRIVS(privs);
+  PAM_MODUTIL_DEF_PRIVS(privs2);
+
+  ret = PAM_AUTH_ERR;
+
+  if (! init_yubikey(&yk)) {
+    DBG(("Failed initializing YubiKey"));
+    goto out;
+  }
+
+  if (! check_firmware_version(yk, cfg->debug, true)) {
+    DBG(("YubiKey does not support Challenge-Response (version 2.2 required)"));
+    goto out;
+  }
+
+#ifdef HAVE_PAM_MODUTIL_GETPWNAM
+  p = pam_modutil_getpwnam (pamh, username);
+#else
+  p = getpwnam (username);
+#endif
+  if (p == NULL) {
+      DBG (("getpwnam: %s", strerror(errno)));
+      goto out;
+  }
+
+  if (! get_user_challenge_file (yk, cfg->chalresp_path, p, &userfile)) {
+    DBG(("Failed getting user challenge file for user %s", username));
+    goto out;
+  }
+
+  DBG(("Loading challenge from file %s", userfile));
+
+  /* Drop privileges before opening user file (if we're not using system-wide dir). */
+  if (!cfg->chalresp_path) {
+    if (pam_modutil_drop_priv(pamh, &privs, p)) {
+      DBG (("could not drop privileges"));
+      goto out;
+    }
+  }
+
+  fd = open(userfile, O_RDONLY, 0);
+  if (fd < 0) {
+      DBG (("Cannot open file: %s (%s)", userfile, strerror(errno)));
+      goto restpriv_out;
+  }
+
+  if (fstat(fd, &st) < 0) {
+      DBG (("Cannot stat file: %s (%s)", userfile, strerror(errno)));
+      close(fd);
+      goto restpriv_out;
+  }
+
+  if (!S_ISREG(st.st_mode)) {
+      DBG (("%s is not a regular file", userfile));
+      close(fd);
+      goto restpriv_out;
+  }
+
+  f = fdopen(fd, "r");
+  if (f == NULL) {
+      DBG (("fdopen: %s", strerror(errno)));
+      close(fd);
+      goto restpriv_out;
+  }
+
+  if (! load_chalresp_state(f, &state, cfg->debug))
+    goto restpriv_out;
+
+  if (fclose(f) < 0) {
+    f = NULL;
+    goto restpriv_out;
+  }
+  f = NULL;
+
+  if (!cfg->chalresp_path) {
+    if (pam_modutil_regain_priv(pamh, &privs)) {
+      DBG (("could not restore privileges"));
+      goto out;
+    }
+  }
+
+  if (! challenge_response(yk, state.slot, state.challenge, state.challenge_len,
+			   true, true, false,
+			   buf, sizeof(buf), &response_len)) {
+    DBG(("Challenge-response FAILED"));
+    goto out;
+  }
+
+  /*
+   * Check YubiKey response against the expected response
+   */
+
+  yubikey_hex_encode(response_hex, buf, response_len);
+  if(state.salt_len > 0) { /* the expected response has gone through pbkdf2 */
+    YK_PRF_METHOD prf_method = {20, yk_hmac_sha1};
+    yk_pbkdf2(response_hex, (unsigned char*)state.salt, state.salt_len, state.iterations,
+        (unsigned char*)buf, response_len, &prf_method);
+  }
+
+  if (memcmp(buf, state.response, state.response_len) == 0) {
+    ret = PAM_SUCCESS;
+  } else {
+    DBG(("Unexpected C/R response : %s", response_hex));
+    goto out;
+  }
+
+  DBG(("Got the expected response, generating new challenge (%u bytes).", CR_CHALLENGE_SIZE));
+
+  errstr = "Error generating new challenge, please check syslog or contact your system administrator";
+  if (generate_random(state.challenge, sizeof(state.challenge))) {
+    DBG(("Failed generating new challenge!"));
+    goto out;
+  }
+
+  errstr = "Error communicating with Yubikey, please check syslog or contact your system administrator";
+  if (! challenge_response(yk, state.slot, state.challenge, CR_CHALLENGE_SIZE,
+			   true, true, false,
+			   buf, sizeof(buf), &response_len)) {
+    DBG(("Second challenge-response FAILED"));
+    goto out;
+  }
+
+  /* There is a bug that makes the YubiKey 2.2 send the same response for all challenges
+     unless HMAC_LT64 is set, check for that here */
+  if (memcmp(buf, state.response, state.response_len) == 0) {
+    errstr = "Same response for second challenge, YubiKey should be reconfigured with the option HMAC_LT64";
+    goto out;
+  }
+
+  /* the yk_* functions leave 'junk' in errno */
+  errno = 0;
+
+  /*
+   * Write the challenge and response we will expect the next time to the state file.
+   */
+  if (response_len > sizeof(state.response)) {
+    DBG(("Got too long response ??? (%u/%zu)", response_len, sizeof(state.response)));
+    goto out;
+  }
+  memcpy (state.response, buf, response_len);
+  state.response_len = response_len;
+
+  /* point to the fresh privs structure.. */
+  privs = privs2;
+  /* Drop privileges before creating new challenge file. */
+  if (!cfg->chalresp_path) {
+    if (pam_modutil_drop_priv(pamh, &privs, p)) {
+        DBG (("could not drop privileges"));
+        goto out;
+    }
+  }
+
+  /* Write out the new file */
+  tmpfile = malloc(strlen(userfile) + 1 + strlen(TMPFILE_SUFFIX));
+  if (! tmpfile)
+    goto restpriv_out;
+  strcpy(tmpfile, userfile);
+  strcat(tmpfile, TMPFILE_SUFFIX);
+
+  fd = mkstemp(tmpfile);
+  if (fd < 0) {
+      DBG (("Cannot open file: %s (%s)", tmpfile, strerror(errno)));
+      goto restpriv_out;
+  }
+
+  if (fchmod (fd, S_IRUSR | S_IWUSR) != 0) {
+      DBG (("could not set correct file permissions"));
+      goto restpriv_out;
+  }
+
+  f = fdopen(fd, "w");
+  if (! f) {
+    close(fd);
+    goto restpriv_out;
+  }
+
+  errstr = "Error updating Yubikey challenge, please check syslog or contact your system administrator";
+  if (! write_chalresp_state (f, &state))
+    goto out;
+  if (fclose(f) < 0) {
+    f = NULL;
+    goto restpriv_out;
+  }
+  f = NULL;
+  if (rename(tmpfile, userfile) < 0) {
+    goto restpriv_out;
+  }
+
+  DBG(("Challenge-response success!"));
+  errstr = NULL;
+  errno = 0;
+  yk_errno = 0;
+
+restpriv_out:
+  if (!cfg->chalresp_path) {
+    if (pam_modutil_regain_priv(pamh, &privs)) {
+        DBG (("could not restore privileges"));
+    }
+  }
+
+ out:
+  if (yk_errno) {
+    if (yk_errno == YK_EUSBERR) {
+      syslog(LOG_ERR, "USB error: %s", yk_usb_strerror());
+      DBG(("USB error: %s", yk_usb_strerror()));
+    } else {
+      syslog(LOG_ERR, "Yubikey core error: %s", yk_strerror(yk_errno));
+      DBG(("Yubikey core error: %s", yk_strerror(yk_errno)));
+    }
+  }
+
+  if (errstr)
+    display_error(pamh, errstr);
+
+  if (errno) {
+    syslog(LOG_ERR, "Challenge response failed: %s", strerror(errno));
+    DBG(("Challenge response failed: %s", strerror(errno)));
+  }
+
+  if (yk)
+    yk_close_key(yk);
+  yk_release();
+
+  if (f)
+    fclose(f);
+
+  free(userfile);
+  free(tmpfile);
+  return ret;
+}
+#endif /* HAVE_CR */
+
+static void
+parse_cfg (int flags, int argc, const char **argv, struct cfg *cfg)
+{
+  int i;
+
+  memset (cfg, 0, sizeof(struct cfg));
+  cfg->client_id = 0;
+  cfg->token_id_length = DEFAULT_TOKEN_ID_LEN;
+  cfg->mode = CLIENT;
+
+  for (i = 0; i < argc; i++)
     {
-      size_t len;
-      part = strstr(filter, "%u");
-      if(part)
-        len = part - filter;
-      else
-        len = strlen(filter);
-      if (output)
+      if (strncmp (argv[i], "id=", 3) == 0)
+	sscanf (argv[i], "id=%d", &cfg->client_id);
+      if (strncmp (argv[i], "key=", 4) == 0)
+	cfg->client_key = argv[i] + 4;
+      if (strcmp (argv[i], "debug") == 0)
+	cfg->debug = 1;
+      if (strcmp (argv[i], "alwaysok") == 0)
+	cfg->alwaysok = 1;
+      if (strcmp (argv[i], "verbose_otp") == 0)
+	cfg->verbose_otp = 1;
+      if (strcmp (argv[i], "try_first_pass") == 0)
+	cfg->try_first_pass = 1;
+      if (strcmp (argv[i], "use_first_pass") == 0)
+	cfg->use_first_pass = 1;
+      if (strncmp (argv[i], "authfile=", 9) == 0)
+	cfg->auth_file = argv[i] + 9;
+      if (strncmp (argv[i], "authgroup=", 10) == 0)
+  cfg->auth_group = argv[i] + 10;
+      if (strncmp (argv[i], "capath=", 7) == 0)
+	cfg->capath = argv[i] + 7;
+      if (strncmp (argv[i], "cainfo=", 7) == 0)
+        cfg->cainfo = argv[i] + 7;
+      if (strncmp (argv[i], "proxy=", 6) == 0)
+	cfg->proxy = argv[i] + 6;
+      if (strncmp (argv[i], "url=", 4) == 0)
+	cfg->url = argv[i] + 4;
+      if (strncmp (argv[i], "urllist=", 8) == 0)
+	cfg->urllist = argv[i] + 8;
+      if (strncmp (argv[i], "ldapserver=", 11) == 0)
+	cfg->ldapserver = argv[i] + 11;
+      if (strncmp (argv[i], "ldap_uri=", 9) == 0)
+	cfg->ldap_uri = argv[i] + 9;
+      if (strncmp (argv[i], "ldap_bind_user=", 15) == 0)
+	cfg->ldap_bind_user = argv[i] + 15;
+      if (strncmp (argv[i], "ldap_bind_password=", 19) == 0)
+	cfg->ldap_bind_password = argv[i] + 19;
+      if (strncmp (argv[i], "ldap_filter=", 12) == 0)
+	cfg->ldap_filter = argv[i] + 12;
+      if (strncmp (argv[i], "ldap_cacertfile=", 16) == 0)
+        cfg->ldap_cacertfile = argv[i] + 16;
+      if (strncmp (argv[i], "ldapdn=", 7) == 0)
+	cfg->ldapdn = argv[i] + 7;
+      if (strncmp (argv[i], "user_attr=", 10) == 0)
+	cfg->user_attr = argv[i] + 10;
+      if (strncmp (argv[i], "yubi_attr=", 10) == 0)
+	cfg->yubi_attr = argv[i] + 10;
+      if (strncmp (argv[i], "yubi_attr_prefix=", 17) == 0)
+	cfg->yubi_attr_prefix = argv[i] + 17;
+      if (strncmp (argv[i], "token_id_length=", 16) == 0)
+	sscanf (argv[i], "token_id_length=%u", &cfg->token_id_length);
+      if (strcmp (argv[i], "mode=challenge-response") == 0)
+	cfg->mode = CHRESP;
+      if (strcmp (argv[i], "mode=client") == 0)
+	cfg->mode = CLIENT;
+      if (strncmp (argv[i], "chalresp_path=", 14) == 0)
+	cfg->chalresp_path = argv[i] + 14;
+    }
+
+  if (cfg->debug)
+    {
+      D (("called."));
+      D (("flags %d argc %d", flags, argc));
+      for (i = 0; i < argc; i++)
+	D (("argv[%d]=%s", i, argv[i]));
+      D (("id=%u", cfg->client_id));
+      D (("key=%s", cfg->client_key ? cfg->client_key : "(null)"));
+      D (("debug=%d", cfg->debug));
+      D (("alwaysok=%d", cfg->alwaysok));
+      D (("verbose_otp=%d", cfg->verbose_otp));
+      D (("try_first_pass=%d", cfg->try_first_pass));
+      D (("use_first_pass=%d", cfg->use_first_pass));
+      D (("authfile=%s", cfg->auth_file ? cfg->auth_file : "(null)"));
+      D (("ldapserver=%s", cfg->ldapserver ? cfg->ldapserver : "(null)"));
+      D (("ldap_uri=%s", cfg->ldap_uri ? cfg->ldap_uri : "(null)"));
+      D (("ldap_bind_user=%s", cfg->ldap_bind_user ? cfg->ldap_bind_user : "(null)"));
+      D (("ldap_bind_password=%s", cfg->ldap_bind_password ? cfg->ldap_bind_password : "(null)"));
+      D (("ldap_filter=%s", cfg->ldap_filter ? cfg->ldap_filter : "(null)"));
+      D (("ldap_cacertfile=%s", cfg->ldap_cacertfile ? cfg->ldap_cacertfile : "(null)"));
+      D (("ldapdn=%s", cfg->ldapdn ? cfg->ldapdn : "(null)"));
+      D (("user_attr=%s", cfg->user_attr ? cfg->user_attr : "(null)"));
+      D (("yubi_attr=%s", cfg->yubi_attr ? cfg->yubi_attr : "(null)"));
+      D (("yubi_attr_prefix=%s", cfg->yubi_attr_prefix ? cfg->yubi_attr_prefix : "(null)"));
+      D (("url=%s", cfg->url ? cfg->url : "(null)"));
+      D (("urllist=%s", cfg->urllist ? cfg->urllist : "(null)"));
+      D (("capath=%s", cfg->capath ? cfg->capath : "(null)"));
+      D (("cainfo=%s", cfg->cainfo ? cfg->cainfo : "(null)"));
+      D (("proxy=%s", cfg->proxy ? cfg->proxy : "(null)"));
+      D (("token_id_length=%d", cfg->token_id_length));
+      D (("mode=%s", cfg->mode == CLIENT ? "client" : "chresp" ));
+      D (("chalresp_path=%s", cfg->chalresp_path ? cfg->chalresp_path : "(null)"));
+    }
+}
+
+PAM_EXTERN int
+pam_sm_authenticate (pam_handle_t * pamh,
+		     int flags, int argc, const char **argv)
+{
+  int retval, rc;
+  const char *user = NULL;
+  const char *password = NULL;
+  char otp[MAX_TOKEN_ID_LEN + TOKEN_OTP_LEN + 1] = { 0 };
+  char otp_id[MAX_TOKEN_ID_LEN + 1] = { 0 };
+  size_t password_len = 0;
+  int skip_bytes = 0;
+  int valid_token = 0;
+  struct pam_conv *conv;
+  const struct pam_message *pmsg[1];
+  struct pam_message msg[1] = {{0}};
+  struct pam_response *resp = NULL;
+  int nargs = 1;
+  ykclient_t *ykc = NULL;
+  struct cfg cfg_st;
+  struct cfg *cfg = &cfg_st; /* for DBG macro */
+  size_t templates = 0;
+  char *urls[10];
+  char *tmpurl = NULL;
+  char *onlypasswd = NULL;
+
+  parse_cfg (flags, argc, argv, cfg);
+
+  DBG (("pam_yubico version: %s", VERSION));
+
+  if (cfg->token_id_length > MAX_TOKEN_ID_LEN)
+  {
+    DBG (("configuration error: token_id_length too long. Maximum acceptable value : %u", MAX_TOKEN_ID_LEN));
+    retval = PAM_AUTHINFO_UNAVAIL;
+    goto done;
+  }
+
+  retval = pam_get_user (pamh, &user, NULL);
+  if (retval != PAM_SUCCESS)
+    {
+      DBG (("get user returned error: %s", pam_strerror (pamh, retval)));
+      goto done;
+    }
+  DBG (("get user returned: %s", user));
+
+  if (cfg->mode == CHRESP) {
+#if HAVE_CR
+    return do_challenge_response(pamh, cfg, user);
+#else
+    DBG (("no support for challenge/response"));
+    retval = PAM_AUTH_ERR;
+    goto done;
+#endif
+  }
+
+  if (cfg->try_first_pass || cfg->use_first_pass)
+    {
+      retval = pam_get_item (pamh, PAM_AUTHTOK, (const void **) &password);
+      if (retval != PAM_SUCCESS)
+	{
+	  DBG (("get password returned error: %s",
+	      pam_strerror (pamh, retval)));
+	  goto done;
+	}
+      DBG (("get password returned: %s", password));
+    }
+
+  if (cfg->use_first_pass && password == NULL)
+    {
+      DBG (("use_first_pass set and no password, giving up"));
+      retval = PAM_AUTH_ERR;
+      goto done;
+    }
+
+  if(ykclient_global_init() != YKCLIENT_OK)
+    {
+      DBG (("Failed initializing ykclient library"));
+      retval = PAM_AUTHINFO_UNAVAIL;
+      goto done;
+    }
+  rc = ykclient_init (&ykc);
+  if (rc != YKCLIENT_OK)
+    {
+      DBG (("ykclient_init() failed (%d): %s", rc, ykclient_strerror (rc)));
+      retval = PAM_AUTHINFO_UNAVAIL;
+      goto done;
+    }
+
+  rc = ykclient_set_client_b64 (ykc, cfg->client_id, cfg->client_key);
+  if (rc != YKCLIENT_OK)
+    {
+      DBG (("ykclient_set_client_b64() failed (%d): %s",
+	    rc, ykclient_strerror (rc)));
+      retval = PAM_AUTHINFO_UNAVAIL;
+      goto done;
+    }
+
+  if (cfg->client_key)
+    ykclient_set_verify_signature (ykc, 1);
+
+  if (cfg->capath)
+    ykclient_set_ca_path (ykc, cfg->capath);
+
+  if (cfg->cainfo)
+    ykclient_set_ca_info (ykc, cfg->cainfo);
+
+  if (cfg->proxy)
+    ykclient_set_proxy (ykc, cfg->proxy);
+
+  if (cfg->url)
+    {
+      rc = ykclient_set_url_template (ykc, cfg->url);
+      if (rc != YKCLIENT_OK)
+	{
+	  DBG (("ykclient_set_url_template() failed (%d): %s",
+		rc, ykclient_strerror (rc)));
+	  retval = PAM_AUTHINFO_UNAVAIL;
+	  goto done;
+	}
+    }
+
+  if (cfg->urllist)
+    {
+      char *saveptr = NULL;
+      char *part = NULL;
+      tmpurl = strdup(cfg->urllist);
+
+      while ((part = strtok_r(templates == 0 ? tmpurl : NULL, ";", &saveptr)))
+	{
+	  if(templates == 10)
+	    {
+	      DBG (("maximum 10 urls supported in list."));
+	      retval = PAM_AUTHINFO_UNAVAIL;
+	      goto done;
+	    }
+	  urls[templates] = strdup(part);
+	  templates++;
+	}
+      rc = ykclient_set_url_bases (ykc, templates, (const char **)urls);
+      if (rc != YKCLIENT_OK)
+	{
+	  DBG (("ykclient_set_url_bases() failed (%d): %s",
+		rc, ykclient_strerror (rc)));
+	  retval = PAM_AUTHINFO_UNAVAIL;
+	  goto done;
+	}
+    }
+
+  if (password == NULL)
+    {
+      retval = pam_get_item (pamh, PAM_CONV, (const void **) &conv);
+      if (retval != PAM_SUCCESS)
+	{
+	  DBG (("get conv returned error: %s", pam_strerror (pamh, retval)));
+	  goto done;
+	}
+
+      pmsg[0] = &msg[0];
+      {
+#define QUERY_TEMPLATE "YubiKey for `%s': "
+	size_t len = strlen (QUERY_TEMPLATE) + strlen (user);
+	int wrote;
+
+	msg[0].msg = malloc (len);
+	if (!msg[0].msg)
+	  {
+	    retval = PAM_BUF_ERR;
+	    goto done;
+	  }
+
+	wrote = snprintf ((char *) msg[0].msg, len, QUERY_TEMPLATE, user);
+	if (wrote < 0 || wrote >= len)
+	  {
+	    retval = PAM_BUF_ERR;
+	    goto done;
+	  }
+      }
+      msg[0].msg_style = cfg->verbose_otp ? PAM_PROMPT_ECHO_ON : PAM_PROMPT_ECHO_OFF;
+
+      retval = conv->conv (nargs, pmsg, &resp, conv->appdata_ptr);
+
+      if (retval != PAM_SUCCESS)
+	{
+	  DBG (("conv returned error: %s", pam_strerror (pamh, retval)));
+	  goto done;
+	}
+
+      if (resp->resp == NULL)
+	{
+	  DBG (("conv returned NULL passwd?"));
+	  retval = PAM_AUTH_ERR;
+	  goto done;
+	}
+
+      DBG (("conv returned %zu bytes", strlen(resp->resp)));
+
+      password = resp->resp;
+    }
+
+  password_len = strlen (password);
+  if (password_len < (cfg->token_id_length + TOKEN_OTP_LEN))
+    {
+      DBG (("OTP too short to be considered : %zu < %u", password_len, (cfg->token_id_length + TOKEN_OTP_LEN)));
+      retval = PAM_AUTH_ERR;
+      goto done;
+    }
+
+  /* In case the input was systempassword+YubiKeyOTP, we want to skip over
+     "systempassword" when copying the token_id and OTP to separate buffers */
+  skip_bytes = password_len - (cfg->token_id_length + TOKEN_OTP_LEN);
+
+  DBG (("Skipping first %i bytes. Length is %zu, token_id set to %u and token OTP always %u.",
+	skip_bytes, password_len, cfg->token_id_length, TOKEN_OTP_LEN));
+
+  /* Copy full YubiKey output (public ID + OTP) into otp */
+  strncpy (otp, password + skip_bytes, sizeof (otp) - 1);
+  /* Copy only public ID into otp_id. Destination buffer is zeroed. */
+  strncpy (otp_id, password + skip_bytes, cfg->token_id_length);
+
+  DBG (("OTP: %s ID: %s ", otp, otp_id));
+
+  /* user entered their system password followed by generated OTP? */
+  if (password_len > TOKEN_OTP_LEN + cfg->token_id_length)
+    {
+      onlypasswd = strdup (password);
+
+      if (! onlypasswd) {
+	retval = PAM_BUF_ERR;
+	goto done;
+      }
+
+      onlypasswd[password_len - (TOKEN_OTP_LEN + cfg->token_id_length)] = '\0';
+
+      DBG (("Extracted a probable system password entered before the OTP - "
+	    "setting item PAM_AUTHTOK"));
+
+      retval = pam_set_item (pamh, PAM_AUTHTOK, onlypasswd);
+      if (retval != PAM_SUCCESS)
+	{
+	  DBG (("set_item returned error: %s", pam_strerror (pamh, retval)));
+	  goto done;
+	}
+    }
+  else
+    password = NULL;
+
+  rc = ykclient_request (ykc, otp);
+
+  DBG (("ykclient return value (%d): %s", rc,
+	ykclient_strerror (rc)));
+  DBG (("ykclient url used: %s", ykclient_get_last_url(ykc)));
+
+  switch (rc)
+    {
+    case YKCLIENT_OK:
+      break;
+
+    case YKCLIENT_BAD_OTP:
+    case YKCLIENT_REPLAYED_OTP:
+      retval = PAM_AUTH_ERR;
+      goto done;
+
+    default:
+      retval = PAM_AUTHINFO_UNAVAIL;
+      goto done;
+    }
+
+  /* authorize the user with supplied token id */
+  if (cfg->ldapserver != NULL || cfg->ldap_uri != NULL)
+    valid_token = authorize_user_token_ldap (cfg, user, otp_id);
+  else
+    valid_token = authorize_user_token (cfg, user, otp_id, pamh);
+
+  switch(valid_token)
+    {
+    case 1:
+      retval = PAM_SUCCESS;
+      break;
+    case 0:
+      DBG (("Internal error while validating user"));
+      retval = PAM_AUTHINFO_UNAVAIL;
+      break;
+    case -1:
+      DBG (("Unauthorized token for this user"));
+      retval = PAM_AUTH_ERR;
+      break;
+    case -2:
+      DBG (("Unknown user"));
+      retval = PAM_USER_UNKNOWN;
+      break;
+    default:
+      DBG (("Unhandled value for token-user validation"))
+      retval = PAM_AUTHINFO_UNAVAIL;
+    }
+
+done:
+  if (onlypasswd)
+    free(onlypasswd);
+  if (templates > 0)
+    {
+      size_t i;
+      for(i = 0; i < templates; i++)
         {
-          strncpy(output, filter, len);
-          output += len;
-        }
-      result += len;
-      filter += len + 2;
-      if(part)
-        {
-          if(output)
-            {
-              strncpy(output, user, strlen(user));
-              output += strlen(user);
-            }
-          result += strlen(user);
+	  free(urls[i]);
         }
     }
-  while(part);
+  if (tmpurl)
+    free(tmpurl);
+  if (ykc)
+    {
+      ykclient_done (&ykc);
+      ykclient_global_done();
+    }
+  if (cfg->alwaysok && retval != PAM_SUCCESS)
+    {
+      DBG (("alwaysok needed (otherwise return with %d)", retval));
+      retval = PAM_SUCCESS;
+    }
+  DBG (("done. [%s]", pam_strerror (pamh, retval)));
+  pam_set_data (pamh, "yubico_setcred_return", (void*)(intptr_t)retval, NULL);
 
-  if(output)
-    *output = '\0';
-  return(result + 1);
+  if (resp)
+    {
+      if (resp->resp)
+        free (resp->resp);
+      free (resp);
+    }
+
+  if(msg[0].msg)
+    {
+      free((char*)msg[0].msg);
+    }
+
+  return retval;
 }
 
-char *filter_printf(const char *filter, const char *user) {
-  char *result = malloc(filter_result_len(filter, user, NULL));
-  filter_result_len(filter, user, result);
-  return result;
+PAM_EXTERN int
+pam_sm_setcred (
+    pam_handle_t *pamh __attribute__((unused)), int flags __attribute__((unused)),
+    int argc __attribute__((unused)), const char *argv[] __attribute__((unused)))
+{
+  return PAM_SUCCESS;
 }
+
+PAM_EXTERN int
+pam_sm_acct_mgmt(pam_handle_t *pamh, int flags __attribute__((unused)),
+    int argc __attribute__((unused)), const char **argv __attribute__((unused)))
+{
+  int retval;
+  int rc = pam_get_data(pamh, "yubico_setcred_return", (const void**)&retval);
+  if (rc == PAM_SUCCESS && retval == PAM_SUCCESS) {
+    D (("pam_sm_acct_mgmt returing PAM_SUCCESS"));
+    return PAM_SUCCESS;
+  }
+  D (("pam_sm_acct_mgmt returing PAM_AUTH_ERR:%d", rc));
+  return PAM_AUTH_ERR;
+}
+
+PAM_EXTERN int
+pam_sm_open_session(
+    pam_handle_t *pamh __attribute__((unused)), int flags __attribute__((unused)),
+    int argc __attribute__((unused)), const char *argv[] __attribute__((unused)))
+{
+
+  D(("pam_sm_open_session"));
+  return (PAM_SUCCESS);
+}
+
+PAM_EXTERN int
+pam_sm_close_session(
+    pam_handle_t *pamh __attribute__((unused)), int flags __attribute__((unused)),
+    int argc __attribute__((unused)), const char *argv[] __attribute__((unused)))
+{
+  D(("pam_sm_close_session"));
+  return (PAM_SUCCESS);
+}
+
+PAM_EXTERN int
+pam_sm_chauthtok(
+    pam_handle_t *pamh __attribute__((unused)), int flags __attribute__((unused)),
+    int argc __attribute__((unused)), const char *argv[] __attribute__((unused)))
+{
+  D(("pam_sm_chauthtok"));
+  return (PAM_SERVICE_ERR);
+}
+
+
+#ifdef PAM_STATIC
+
+struct pam_module _pam_yubico_modstruct = {
+  "pam_yubico",
+  pam_sm_authenticate,
+  pam_sm_setcred,
+  pam_sm_acct_mgmt,
+  pam_sm_open_session,
+  pam_sm_close_session,
+  pam_sm_chauthtok
+};
+
+#endif

--- a/util.h
+++ b/util.h
@@ -92,7 +92,7 @@ int write_chalresp_state(FILE *f, CR_STATE *state);
 
 int init_yubikey(YK_KEY **yk);
 int check_firmware_version(YK_KEY *yk, bool verbose, bool quiet);
-int do_check_group(char *username, char *group);
+int check_user_group(char *username, char *group);
 int challenge_response(YK_KEY *yk, int slot,
 		       char *challenge, unsigned int len,
 		       bool hmac, bool may_block, bool verbose,

--- a/util.h
+++ b/util.h
@@ -36,6 +36,8 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <grp.h>
+#include <string.h>
 #include <pwd.h>
 
 #if defined(DEBUG_PAM)
@@ -90,6 +92,7 @@ int write_chalresp_state(FILE *f, CR_STATE *state);
 
 int init_yubikey(YK_KEY **yk);
 int check_firmware_version(YK_KEY *yk, bool verbose, bool quiet);
+int do_check_group(char *username, char *group);
 int challenge_response(YK_KEY *yk, int slot,
 		       char *challenge, unsigned int len,
 		       bool hmac, bool may_block, bool verbose,


### PR DESCRIPTION
Okay, I had initially submitted a pull request some time last year to add this feature, and you had recommended some changes. I ended up moving 7,400 miles across the globe for an opportunity that presented itself and very unfortunately have been neglecting contributions to the open source world. I'm finally settled in, so I made some changes best that I could remember per some of your recommendations.

I've changed the methodology of determining the users membership to the group - I'm now using getgrnam() and checking that the member is in the group instead pulling a list of the members groups. I've also eliminated the need of a malloc()/free() entirely. I've added some D(()) and DBG(()) statements as well as changing the name of the check group function to something a little more fitting of the format already used. I deleted the old repo in order to clean up the whitespace changes my IDE decided to make...

I'd like to also add this ability to the other auth methods (i.e. u2f etc) in time. Please review and let me know your opinion. :)

~J