### PR TITLE
Added authgroup PAM option for challenge-response mode

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,3 +42,7 @@ Drop permissions before opening user files.
 
 Fredrik Thulin <fredrik@yubico.com>
 Maintainer alumni, helped on drop_privs.c, utils.c, and more.
+
+Jonathan D. Hall <jhall@futuresouth.us>
+Added authgroup PAM module option for challenge-response
+

--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -109,6 +109,7 @@ struct cfg
   int try_first_pass;
   int use_first_pass;
   const char *auth_file;
+  const char *auth_group;
   const char *capath;
   const char *cainfo;
   const char *proxy;
@@ -439,7 +440,7 @@ do_challenge_response(pam_handle_t *pamh, struct cfg *cfg, const char *username)
   char *userfile = NULL, *tmpfile = NULL;
   FILE *f = NULL;
   char buf[CR_RESPONSE_SIZE + 16], response_hex[CR_RESPONSE_SIZE * 2 + 1];
-  int ret, fd;
+  int ret, fd, result;
 
   unsigned int response_len = 0;
   YK_KEY *yk = NULL;
@@ -449,6 +450,18 @@ do_challenge_response(pam_handle_t *pamh, struct cfg *cfg, const char *username)
 
   struct passwd *p;
   struct stat st;
+    
+  if(cfg->auth_group) {
+    result = check_user_group((char*)username,(char*)cfg->auth_group);
+    
+    if(result == 1) {
+      errstr = NULL;
+      errno = 0;
+      ret = PAM_SUCCESS;
+      DBG(("User %s is not in group %s - skipping YubiKey requirement for login!", username, cfg->auth_group));
+      goto out;
+    }
+  }
 
   /* we must declare two sepparate privs structures as they can't be reused */
   PAM_MODUTIL_DEF_PRIVS(privs);
@@ -711,6 +724,8 @@ parse_cfg (int flags, int argc, const char **argv, struct cfg *cfg)
 	cfg->use_first_pass = 1;
       if (strncmp (argv[i], "authfile=", 9) == 0)
 	cfg->auth_file = argv[i] + 9;
+      if (strncmp (argv[i], "authgroup=", 10) == 0)
+  cfg->auth_group = argv[i] + 10;
       if (strncmp (argv[i], "capath=", 7) == 0)
 	cfg->capath = argv[i] + 7;
       if (strncmp (argv[i], "cainfo=", 7) == 0)

--- a/util.c
+++ b/util.c
@@ -227,6 +227,28 @@ check_firmware_version(YK_KEY *yk, bool verbose, bool quiet)
 }
 
 int
+check_user_group(char *username, char *group)
+{
+  struct group *group_ptr;
+  char **group_member;
+  
+  if((group_ptr = getgrnam(group)) == NULL) {
+    // Group was not found... Return a fail
+    D(("Group %s does not exist... Skipping group verification and returning valid!\n",group));
+    return 1;
+  }
+  
+  for (group_member = group_ptr->gr_mem; *group_member != NULL; group_member++) {
+    if(strcmp(*group_member,username) == 0) {
+      // We found the user...
+      D(("User: %s is part of the Group: %s\n", username,group));
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int
 init_yubikey(YK_KEY **yk)
 {
 	if (!yk_init())

--- a/util.h
+++ b/util.h
@@ -36,6 +36,8 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <grp.h>
+#include <string.h>
 #include <pwd.h>
 
 #if defined(DEBUG_PAM)
@@ -90,6 +92,7 @@ int write_chalresp_state(FILE *f, CR_STATE *state);
 
 int init_yubikey(YK_KEY **yk);
 int check_firmware_version(YK_KEY *yk, bool verbose, bool quiet);
+int check_user_group(char *username, char *group);
 int challenge_response(YK_KEY *yk, int slot,
 		       char *challenge, unsigned int len,
 		       bool hmac, bool may_block, bool verbose,


### PR DESCRIPTION
Okay, my apologies on how long it took me to get back to this. I moved across the globe and have been settling in and adjusting. Between the new job and trying to get situated, time has been a little chaotic.

I can't recall all the recommendations you originally made when I first submitted this patch, but I did my best to make sure I covered as much as I could remember. I used getgrnam() to pull a list of members in the group and compared the user to that versus getting a list of groups the member was in. I also eliminated the malloc()/free() as it wasn't needed. I've added D(()) and DBG(()) statements as well. 

Please let me know if you see anything else you can point out/improve on. I'm currently using this pam module on two OS X machines and a Slackware box. So far, so good. 

I had botched up the repo and really didn't want to go through the hassle of cleaning it up, so I simply dropped the fork and recreated, pushed the changes and requested another pull.