### PR TITLE
Improvements for nullok parameter

### DIFF
--- a/pam_yubico.8.txt
+++ b/pam_yubico.8.txt
@@ -41,6 +41,9 @@ Before prompting the user for their password, the module first tries the previou
 *use_first_pass*::
 The argument use_first_pass forces the module to use a previous stacked modules password and will never prompt the user - if no password is available or the password is not appropriate, the user will be denied access.
 
+*nullok*::
+If set, don’t fail when there are no tokens declared for the user in the authorization mapping files or in LDAP. This can be used to make YubiKey authentication optional unless the user has associated tokens.
+
 *urllist*=_list_::
 List of URL templates to be used. This is set by calling ykclient_set_url_bases.
 The list should be in the format:

--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -842,6 +842,7 @@ parse_cfg (int flags, int argc, const char **argv, struct cfg *cfg)
   DBG ("verbose_otp=%d", cfg->verbose_otp);
   DBG ("try_first_pass=%d", cfg->try_first_pass);
   DBG ("use_first_pass=%d", cfg->use_first_pass);
+  DBG ("nullok=%d", cfg->nullok);
   DBG ("authfile=%s", cfg->auth_file ? cfg->auth_file : "(null)");
   DBG ("ldapserver=%s", cfg->ldapserver ? cfg->ldapserver : "(null)");
   DBG ("ldap_uri=%s", cfg->ldap_uri ? cfg->ldap_uri : "(null)");


### PR DESCRIPTION
This adds missing documentation of the nullok parameter to the man page and makes sure the parameter is printed out in debug mode, which has been forgotten previously.