### PR TITLE
Several file handling hardenings

### DIFF
--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -535,7 +535,7 @@ do_challenge_response(pam_handle_t *pamh, struct cfg *cfg, const char *username)
     }
   }
 
-  fd = open(userfile, O_RDONLY, 0);
+  fd = open(userfile, O_RDONLY | O_CLOEXEC, 0);
   if (fd < 0) {
       DBG ("Cannot open file: %s (%s)", userfile, strerror(errno));
       goto restpriv_out;

--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -819,7 +819,7 @@ parse_cfg (int flags, int argc, const char **argv, struct cfg *cfg)
                 {
                   if(S_ISREG(st.st_mode))
                     {
-                      file = fopen(filename, "a");
+                      file = fopen(filename, "ae");
                       if(file)
                         {
                           cfg->debug_file = file;

--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -654,7 +654,7 @@ do_challenge_response(pam_handle_t *pamh, struct cfg *cfg, const char *username)
   strcpy(tmpfile, userfile);
   strcat(tmpfile, TMPFILE_SUFFIX);
 
-  fd = mkstemp(tmpfile);
+  fd = mkostemp(tmpfile, O_CLOEXEC);
   if (fd < 0) {
       DBG ("Cannot open file: %s (%s)", tmpfile, strerror(errno));
       goto restpriv_out;

--- a/util.c
+++ b/util.c
@@ -188,7 +188,7 @@ int generate_random(void *buf, int len)
 	FILE *u;
 	int res;
 
-	u = fopen("/dev/urandom", "r");
+	u = fopen("/dev/urandom", "re");
 	if (!u) {
 		return -1;
 	}

--- a/util.c
+++ b/util.c
@@ -109,7 +109,7 @@ check_user_token (const char *authfile,
   struct stat st;
   FILE *opwfile;
 
-  fd = open(authfile, O_RDONLY, 0);
+  fd = open(authfile, O_RDONLY | O_CLOEXEC, 0);
   if (fd < 0) {
       if(verbose)
 	  D (debug_file, "Cannot open file: %s (%s)", authfile, strerror(errno));

--- a/ykpamcfg.c
+++ b/ykpamcfg.c
@@ -237,7 +237,7 @@ do_add_hmac_chalresp(YK_KEY *yk, uint8_t slot, bool verbose, char *output_dir, u
 
   umask(077);
 
-  f = fopen (fn, "w");
+  f = fopen (fn, "we");
   if (! f) {
     fprintf (stderr, "Failed opening '%s' for writing : %s\n", fn, strerror (errno));
     goto out;


### PR DESCRIPTION
This hardens the file handling of the module by making use of the `O_CLOEXEC` flag for file descriptors and making sure that `/dev/urandom` is a character based device.