### PR TITLE
Require sudo in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: c
 os:
   - linux


### PR DESCRIPTION
Since the install script currently requires sudo, we should state so
explicetely in the .travis.yml file to make sure we get a sudo-enabled
environment and not a container-based one, as there is no sudo available
in the latter one. The default was changed in August 2017, so when
forking this repository, the Travis CI won't work out-of-the box without
this modification. This is described in some details [here](https://docs.travis-ci.com/user/reference/overview/).