### PR TITLE
Fix several format string specifiers

### DIFF
--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -362,7 +362,7 @@ authorize_user_token_ldap (struct cfg *cfg,
 	      /* Compare each value for the attribute against the token id. */
 	      for (i = 0; vals[i] != NULL; i++)
 		{
-		  DBG("LDAP : Checking value %i: %s:%s",
+		  DBG("LDAP : Checking value %zu: %s:%s",
 		      i + 1,
 		      cfg->yubi_attr_prefix ? cfg->yubi_attr_prefix : "",
 		      vals[i]->bv_val);
@@ -745,7 +745,7 @@ parse_cfg (int flags, int argc, const char **argv, struct cfg *cfg)
   for (i = 0; i < argc; i++)
     {
       if (strncmp (argv[i], "id=", 3) == 0)
-	sscanf (argv[i], "id=%d", &cfg->client_id);
+	sscanf (argv[i], "id=%u", &cfg->client_id);
       if (strncmp (argv[i], "key=", 4) == 0)
 	cfg->client_key = argv[i] + 4;
       if (strcmp (argv[i], "debug") == 0)
@@ -859,7 +859,7 @@ parse_cfg (int flags, int argc, const char **argv, struct cfg *cfg)
   DBG ("capath=%s", cfg->capath ? cfg->capath : "(null)");
   DBG ("cainfo=%s", cfg->cainfo ? cfg->cainfo : "(null)");
   DBG ("proxy=%s", cfg->proxy ? cfg->proxy : "(null)");
-  DBG ("token_id_length=%d", cfg->token_id_length);
+  DBG ("token_id_length=%u", cfg->token_id_length);
   DBG ("mode=%s", cfg->mode == CLIENT ? "client" : "chresp" );
   DBG ("chalresp_path=%s", cfg->chalresp_path ? cfg->chalresp_path : "(null)");
 }

--- a/util.c
+++ b/util.c
@@ -419,7 +419,7 @@ load_chalresp_state(FILE *f, CR_STATE *state, bool verbose, FILE *debug_file)
    * 40 is twice the size of CR_RESPONSE_SIZE
    * (twice because we hex encode the challenge and response)
    */
-  r = fscanf(f, "v2:%126[0-9a-z]:%40[0-9a-z]:%64[0-9a-z]:%d:%d", challenge_hex, response_hex, salt_hex, &iterations, &slot);
+  r = fscanf(f, "v2:%126[0-9a-z]:%40[0-9a-z]:%64[0-9a-z]:%u:%d", challenge_hex, response_hex, salt_hex, &iterations, &slot);
   if(r == 5) {
     if (! yubikey_hex_p(salt_hex)) {
       D(debug_file, "Invalid salt hex input : %s", salt_hex);
@@ -427,7 +427,7 @@ load_chalresp_state(FILE *f, CR_STATE *state, bool verbose, FILE *debug_file)
     }
 
     if(verbose) {
-      D(debug_file, "Challenge: %s, hashed response: %s, salt: %s, iterations: %d, slot: %d",
+      D(debug_file, "Challenge: %s, hashed response: %s, salt: %s, iterations: %u, slot: %d",
             challenge_hex, response_hex, salt_hex, iterations, slot);
     }
 


### PR DESCRIPTION
This fixes several specifiers to better represent the data type, which fixes
multiple compiler warnings.