### PR TITLE
Make use of the O_CLOEXEC flag when dealing with file descriptors

### DIFF
--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -535,7 +535,7 @@ do_challenge_response(pam_handle_t *pamh, struct cfg *cfg, const char *username)
     }
   }
 
-  fd = open(userfile, O_RDONLY, 0);
+  fd = open(userfile, O_RDONLY | O_CLOEXEC, 0);
   if (fd < 0) {
       DBG ("Cannot open file: %s (%s)", userfile, strerror(errno));
       goto restpriv_out;

--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -819,7 +819,7 @@ parse_cfg (int flags, int argc, const char **argv, struct cfg *cfg)
                 {
                   if(S_ISREG(st.st_mode))
                     {
-                      file = fopen(filename, "a");
+                      file = fopen(filename, "ae");
                       if(file)
                         {
                           cfg->debug_file = file;

--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -814,15 +814,20 @@ parse_cfg (int flags, int argc, const char **argv, struct cfg *cfg)
           else
             {
               struct stat st;
+              int fd;
               FILE *file;
               if(lstat(filename, &st) == 0)
                 {
                   if(S_ISREG(st.st_mode))
                     {
-                      file = fopen(filename, "ae");
-                      if(file)
+                      fd = open(filename, O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, S_IRUSR | S_IWUSR | S_IRGRP);
+                      if (fd >= 0)
                         {
-                          cfg->debug_file = file;
+                          file = fdopen(fd, "a");
+                          if (file)
+                            {
+                              cfg->debug_file = file;
+                            }
                         }
                     }
                 }

--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -654,7 +654,7 @@ do_challenge_response(pam_handle_t *pamh, struct cfg *cfg, const char *username)
   strcpy(tmpfile, userfile);
   strcat(tmpfile, TMPFILE_SUFFIX);
 
-  fd = mkstemp(tmpfile);
+  fd = mkostemp(tmpfile, O_CLOEXEC);
   if (fd < 0) {
       DBG ("Cannot open file: %s (%s)", tmpfile, strerror(errno));
       goto restpriv_out;

--- a/util.c
+++ b/util.c
@@ -187,8 +187,14 @@ int generate_random(void *buf, int len)
 {
 	FILE *u;
 	int res;
+	int fd;
 
-	u = fopen("/dev/urandom", "re");
+	fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+	if (fd < 0) {
+		return -1;
+	}
+
+	u = fdopen(fd, "r");
 	if (!u) {
 		return -1;
 	}

--- a/util.c
+++ b/util.c
@@ -188,7 +188,7 @@ int generate_random(void *buf, int len)
 	FILE *u;
 	int res;
 
-	u = fopen("/dev/urandom", "r");
+	u = fopen("/dev/urandom", "re");
 	if (!u) {
 		return -1;
 	}

--- a/util.c
+++ b/util.c
@@ -109,7 +109,7 @@ check_user_token (const char *authfile,
   struct stat st;
   FILE *opwfile;
 
-  fd = open(authfile, O_RDONLY, 0);
+  fd = open(authfile, O_RDONLY | O_CLOEXEC, 0);
   if (fd < 0) {
       if(verbose)
 	  D (debug_file, "Cannot open file: %s (%s)", authfile, strerror(errno));

--- a/ykpamcfg.c
+++ b/ykpamcfg.c
@@ -237,7 +237,7 @@ do_add_hmac_chalresp(YK_KEY *yk, uint8_t slot, bool verbose, char *output_dir, u
 
   umask(077);
 
-  f = fopen (fn, "w");
+  f = fopen (fn, "we");
   if (! f) {
     fprintf (stderr, "Failed opening '%s' for writing : %s\n", fn, strerror (errno));
     goto out;

--- a/ykpamcfg.c
+++ b/ykpamcfg.c
@@ -38,6 +38,7 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <fcntl.h>
 
 #include <ykpers.h>
 
@@ -143,6 +144,7 @@ do_add_hmac_chalresp(YK_KEY *yk, uint8_t slot, bool verbose, char *output_dir, u
   unsigned int response_len;
   char *fn;
   struct passwd *p;
+  int fd;
   FILE *f = NULL;
   struct stat st;
 
@@ -237,9 +239,14 @@ do_add_hmac_chalresp(YK_KEY *yk, uint8_t slot, bool verbose, char *output_dir, u
 
   umask(077);
 
-  f = fopen (fn, "we");
-  if (! f) {
+  fd = open (fn, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, S_IRUSR | S_IWUSR);
+  if (fd < 0) {
     fprintf (stderr, "Failed opening '%s' for writing : %s\n", fn, strerror (errno));
+    goto out;
+  }
+  f = fdopen (fd, "w");
+  if (! f) {
+    fprintf (stderr, "fdopen: %s\n", strerror (errno));
     goto out;
   }
 


### PR DESCRIPTION
This series makes use of the O_CLOEXEC flag whenever opening file descriptor, which makes sure that those file descriptors won't be leaked into child processes, even if a final `fclose()` is forgotten (as was the case with #136).