### PR TITLE
Add documentation for cainfo option

### DIFF
--- a/README
+++ b/README
@@ -196,6 +196,9 @@ specify the path where X509 certificates are stored. This is
 required if 'https' or 'ldaps' are used in 'url' and 'ldap_uri'
 respectively.
 
+cainfo::
+Option to allow usage of a CA bundle instead of path.
+
 proxy::
 specify a proxy to connect to the validation server. Valid schemes are
 http://, https://, socks4://, socks4a://, socks5:// or socks5h://.

--- a/pam_yubico.8.txt
+++ b/pam_yubico.8.txt
@@ -56,6 +56,9 @@ This option should not be used, please use the urllist option instead.  Set the 
 *capath*=_path_::
 Specify the path where X509 certificates are stored. This is required if 'https' or 'ldaps' are used in 'url' and 'ldap_uri' respectively.
 
+*cainfo*=_file_::
+Option to allow usage of a CA bundle instead of path.
+
 *proxy*=_proxy_::
 Specify a proxy to connect to the validation server. Valid schemes are http://, https://, socks4://, socks4a://, socks5:// or socks5h://. Socks5h asks the proxy to do the dns resolving. If no scheme or port is specified HTTP proxy port 1080 will be used. E.g. socks5h://user:pass@10.10.0.1:1080
 


### PR DESCRIPTION
This adds documentation about the cainfo parameter to both the README as
well as the man page.