### PR TITLE
README: Add Travis build status

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,5 @@
 == Yubico PAM module
+image:https://travis-ci.org/Yubico/yubico-pam.svg?branch=master["Build Status", link="https://travis-ci.org/Yubico/yubico-pam"]
 
 The Yubico PAM module provides an easy way to integrate the Yubikey
 into your existing user authentication infrastructure.  PAM is used by


### PR DESCRIPTION
This adds a Travis build status badge to the README file, so the current
status can be seen on the GitHub page instantly.