### PR TITLE
ykpamcfg: Use snprintf() instead of strncpy()

### DIFF
--- a/ykpamcfg.c
+++ b/ykpamcfg.c
@@ -104,7 +104,7 @@ parse_args(int argc, char **argv,
       *slot = 2;
       break;
     case 'A':
-      strncpy(*action, optarg, ACTION_MAX_LEN);
+      snprintf(*action, ACTION_MAX_LEN, "%s", optarg);
       break;
     case 'p':
       *output_dir = optarg;


### PR DESCRIPTION
strncpy() is _NOT_ a safe version of strcpy() and it should not be used
(ineffective and dangerous since a NUL termination might be missing).
Instead snprintf() the way to safely construct a string with a given
limit. This commit implements this for the action parsing in ykpamcfg.