### PR TITLE
util.c: Check whether generate_random() was invoked successfully

### DIFF
--- a/util.c
+++ b/util.c
@@ -508,7 +508,10 @@ write_chalresp_state(FILE *f, CR_STATE *state)
     iterations = state->iterations;
   }
 
-  generate_random(salt, CR_SALT_SIZE);
+  if (generate_random(salt, CR_CHALLENGE_SIZE)) {
+    goto out;
+  }
+
   yk_pbkdf2(response_hex, salt, CR_SALT_SIZE, iterations,
       hash, CR_RESPONSE_SIZE, &prf_method);
 


### PR DESCRIPTION
This evaluates the return code from generate_random() within
write_chalresp_state() and returns immediately in case of an error.

This fixes #161.