### PR TITLE
Close file descriptors in case fdopen() fails

### DIFF
--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -833,7 +833,9 @@ parse_cfg (int flags, int argc, const char **argv, struct cfg *cfg)
                           if (file)
                             {
                               cfg->debug_file = file;
-                            }
+                            } else {
+			      close(fd);
+			    }
                         }
                     }
                 }

--- a/util.c
+++ b/util.c
@@ -203,6 +203,7 @@ int generate_random(void *buf, int len)
 
 	u = fdopen(fd, "r");
 	if (!u) {
+		close(fd);
 		return -1;
 	}
 

--- a/ykpamcfg.c
+++ b/ykpamcfg.c
@@ -258,6 +258,7 @@ do_add_hmac_chalresp(YK_KEY *yk, uint8_t slot, bool verbose, char *output_dir, u
   f = fdopen (fd, "w");
   if (! f) {
     fprintf (stderr, "fdopen: %s\n", strerror (errno));
+    close(fd);
     goto out;
   }
 


### PR DESCRIPTION
This makes sure that file descriptors will be closed, even if the
fdopen() call failes, which was overlooked in some cases beforehand.
Should be not an issue in the real world, but let's be as clean as
possible.