### PR TITLE
Fix buffer overflow in write_chalresp_state()

### DIFF
--- a/util.c
+++ b/util.c
@@ -524,7 +524,7 @@ write_chalresp_state(FILE *f, CR_STATE *state)
     iterations = state->iterations;
   }
 
-  if (generate_random(salt, CR_CHALLENGE_SIZE)) {
+  if (generate_random(salt, CR_SALT_SIZE)) {
     goto out;
   }
 


### PR DESCRIPTION
Buffer was defined as CR_SALT_SIZE = 32 but number of random bytes
was CR_CHALLENGE_SIZE = 63.

Bug was introduced with commit 09729861 and on my system has the nasty side effect of corrupting the state file. So, the FIRST authentication with a buggy version works fine but the SECOND or any subsequent one breaks. It took me forever to properly bisect that.

This might be related to or even fix issue #166 as I had the same error. I am running Arch so my software is pretty much the latest version available.

Please review and merge at your discretion.

Thanks a lot,
Björn Wiedenmann