### PR TITLE
Add man page building dependencies to README

### DIFF
--- a/README
+++ b/README
@@ -43,7 +43,7 @@ $ git clone https://github.com/Yubico/yubico-pam.git
 
 This will create the directory `yubico-pam`.
 
-Autoconf, automake, asciidoc and libtool must be installed to create a
+Autoconf, automake, libtool, asciidoc, xsltproc and docbook-xsl must be installed to create a
 compilable source tree.
 
 Generate the build system using:


### PR DESCRIPTION
Some further packages are needed to build the man page so I added them to the README to help other users who are building from source.