### PR TITLE
Improve ldap support

### DIFF
--- a/README
+++ b/README
@@ -177,6 +177,11 @@ in the authorization mapping files or in LDAP.
 This can be used to make YubiKey authentication optional unless
 the user has associated tokens.
 
+ldap_starttls::
+If set, issue a STARTTLS command to the LDAP connection before
+attempting to bind to it. This is a common setup for servers
+that only listen on port 389 but still require TLS.
+
 ldap_bind_as_user::
 If set, use the user logging in to bind to LDAP. This will use the
 password provided by the user via PAM. If this is set, ldapdn

--- a/README
+++ b/README
@@ -236,6 +236,15 @@ ldapdn::
 specify the dn where the users are stored
 (eg: ou=users,dc=domain,dc=com).
 
+ldap_clientcertfile::
+The path to a client cert file to use when talking to the LDAP
+server.  Note this requires 'ldap_clientkeyfile' to be set as well.
+
+ldap_clientkeyfile::
+The path to a key to be used with the client cert when talking to
+the LDAP server.  Note this requires 'ldap_clientcertfile' to be
+set as well.
+
 ldap_bind_user::
 The user to attempt a LDAP bind as.
 

--- a/README
+++ b/README
@@ -177,6 +177,12 @@ in the authorization mapping files or in LDAP.
 This can be used to make YubiKey authentication optional unless
 the user has associated tokens.
 
+ldap_bind_as_user::
+If set, use the user logging in to bind to LDAP. This will use the
+password provided by the user via PAM. If this is set, ldapdn
+and uid_attr must also be set.  Enabling this will cause
+'ldap_bind_user' and 'ldap_bind_password' to be ignored
+
 urllist::
 List  of  URL  templates to be used. This is set by calling
 ykclient_set_url_bases. The list should be in the format :

--- a/pam_yubico.8.txt
+++ b/pam_yubico.8.txt
@@ -80,6 +80,12 @@ The LDAP server host (default LDAP port is used). *Deprecated. Use 'ldap_uri' in
 *ldapdn*=_dn_::
 The distinguished name (DN) where the users are stored (eg: ou=users,dc=domain,dc=com). If 'ldap_filter' is used this is the base from which the subtree search will be performed.
 
+*ldap_clientcertfile*=_clientcertfile_::
+The path to a client cert file to use when talking to the LDAP server.  Note this requires 'ldap_clientkeyfile' to be set as well.
+
+*ldap_clientkeyfile*=_clientkeyfile_::
+The path to a key to be used with the client cert when talking to the LDAP server.  Note this requires 'ldap_clientcertfile' to be set as well.
+
 *user_attr*=_attr_::
 The LDAP attribute used to store user names (eg:cn).
 

--- a/pam_yubico.8.txt
+++ b/pam_yubico.8.txt
@@ -44,6 +44,9 @@ Forces the module to use a previous stacked modules password and will never prom
 *nullok*::
 Don’t fail when there are no tokens declared for the user in the authorization mapping files or in LDAP. This can be used to make YubiKey authentication optional unless the user has associated tokens.
 
+*ldap_starttls*::
+If set, issue a STARTTLS command to the LDAP connection before attempting to bind to it. This is a common setup for servers that only listen on port 389 but still require TLS.
+
 *ldap_bind_as_user*::
 Use the user logging in to bind to ldap. This will use the password provided by the user via PAM. If this is set, ldapdn and uid_attr must also be set.  Enabling this will cause ldap_bind_user and ldap_bind_password to be ignored.
 

--- a/pam_yubico.8.txt
+++ b/pam_yubico.8.txt
@@ -44,6 +44,9 @@ Forces the module to use a previous stacked modules password and will never prom
 *nullok*::
 Don’t fail when there are no tokens declared for the user in the authorization mapping files or in LDAP. This can be used to make YubiKey authentication optional unless the user has associated tokens.
 
+*ldap_bind_as_user*::
+Use the user logging in to bind to ldap. This will use the password provided by the user via PAM. If this is set, ldapdn and uid_attr must also be set.  Enabling this will cause ldap_bind_user and ldap_bind_password to be ignored.
+
 *urllist*=_list_::
 List of URL templates to be used. This is set by calling ykclient_set_url_bases.
 The list should be in the format:

--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -125,6 +125,8 @@ struct cfg
   const char *ldap_filter;
   const char *ldap_cacertfile;
   const char *ldapdn;
+  const char *ldap_clientcertfile;
+  const char *ldap_clientkeyfile;
   const char *user_attr;
   const char *yubi_attr;
   const char *yubi_attr_prefix;
@@ -290,6 +292,19 @@ authorize_user_token_ldap (struct cfg *cfg,
   if (cfg->ldap_uri && cfg->ldap_cacertfile) {
     /* Set CA CERTFILE. This makes ldaps work when using ldap_uri */
     ldap_set_option (0, LDAP_OPT_X_TLS_CACERTFILE, cfg->ldap_cacertfile);
+  }
+
+  if (cfg->ldap_clientcertfile && cfg->ldap_clientkeyfile) {
+    rc = ldap_set_option (NULL, LDAP_OPT_X_TLS_CERTFILE, cfg->ldap_clientcertfile);
+    if (rc != LDAP_SUCCESS) {
+      DBG ("tls_certfile: %s", ldap_err2string (rc));
+      goto done;
+    }
+    rc = ldap_set_option (NULL, LDAP_OPT_X_TLS_KEYFILE, cfg->ldap_clientkeyfile);
+    if (rc != LDAP_SUCCESS) {
+      DBG ("tls_keyfile: %s", ldap_err2string (rc));
+      goto done;
+    }
   }
 
   if (cfg->ldap_starttls) {
@@ -818,6 +833,10 @@ parse_cfg (int flags, int argc, const char **argv, struct cfg *cfg)
 	cfg->ldap_filter = argv[i] + 12;
       if (strncmp (argv[i], "ldap_cacertfile=", 16) == 0)
         cfg->ldap_cacertfile = argv[i] + 16;
+      if (strncmp (argv[i], "ldap_clientcertfile=", 20) == 0)
+        cfg->ldap_clientcertfile = argv[i] + 20;
+      if (strncmp (argv[i], "ldap_clientkeyfile=", 19) == 0)
+        cfg->ldap_clientkeyfile = argv[i] + 19;
       if (strncmp (argv[i], "ldapdn=", 7) == 0)
 	cfg->ldapdn = argv[i] + 7;
       if (strncmp (argv[i], "user_attr=", 10) == 0)
@@ -894,6 +913,8 @@ parse_cfg (int flags, int argc, const char **argv, struct cfg *cfg)
   DBG ("ldap_filter=%s", cfg->ldap_filter ? cfg->ldap_filter : "(null)");
   DBG ("ldap_cacertfile=%s", cfg->ldap_cacertfile ? cfg->ldap_cacertfile : "(null)");
   DBG ("ldapdn=%s", cfg->ldapdn ? cfg->ldapdn : "(null)");
+  DBG ("ldap_clientcertfile=%s", cfg->ldap_clientcertfile ? cfg->ldap_clientcertfile : "(null)");
+  DBG ("ldap_clientkeyfile=%s", cfg->ldap_clientkeyfile ? cfg->ldap_clientkeyfile : "(null)");
   DBG ("user_attr=%s", cfg->user_attr ? cfg->user_attr : "(null)");
   DBG ("yubi_attr=%s", cfg->yubi_attr ? cfg->yubi_attr : "(null)");
   DBG ("yubi_attr_prefix=%s", cfg->yubi_attr_prefix ? cfg->yubi_attr_prefix : "(null)");

--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -110,6 +110,7 @@ struct cfg
   int try_first_pass;
   int use_first_pass;
   int nullok;
+  int ldap_starttls;
   int ldap_bind_as_user;
   const char *auth_file;
   const char *capath;
@@ -289,6 +290,14 @@ authorize_user_token_ldap (struct cfg *cfg,
   if (cfg->ldap_uri && cfg->ldap_cacertfile) {
     /* Set CA CERTFILE. This makes ldaps work when using ldap_uri */
     ldap_set_option (0, LDAP_OPT_X_TLS_CACERTFILE, cfg->ldap_cacertfile);
+  }
+
+  if (cfg->ldap_starttls) {
+    rc = ldap_start_tls_s (ld, NULL, NULL);
+    if (rc != LDAP_SUCCESS) {
+      DBG ("ldap_start_tls: %s", ldap_err2string (rc));
+      goto done;
+    }
   }
 
   /* Allocation of memory for search strings depending on input size */
@@ -781,6 +790,8 @@ parse_cfg (int flags, int argc, const char **argv, struct cfg *cfg)
 	cfg->use_first_pass = 1;
       if (strcmp (argv[i], "nullok") == 0)
 	cfg->nullok = 1;
+      if (strcmp (argv[i], "ldap_starttls") == 0)
+	cfg->ldap_starttls = 1;
       if (strcmp (argv[i], "ldap_bind_as_user") == 0)
 	cfg->ldap_bind_as_user = 1;
       if (strncmp (argv[i], "authfile=", 9) == 0)
@@ -873,6 +884,7 @@ parse_cfg (int flags, int argc, const char **argv, struct cfg *cfg)
   DBG ("try_first_pass=%d", cfg->try_first_pass);
   DBG ("use_first_pass=%d", cfg->use_first_pass);
   DBG ("nullok=%d", cfg->nullok);
+  DBG ("ldap_starttls=%d", cfg->ldap_starttls);
   DBG ("ldap_bind_as_user=%d", cfg->ldap_bind_as_user);
   DBG ("authfile=%s", cfg->auth_file ? cfg->auth_file : "(null)");
   DBG ("ldapserver=%s", cfg->ldapserver ? cfg->ldapserver : "(null)");


### PR DESCRIPTION
This PR adds three features to the LDAP support that we needed:

1. Add the ability to bind as the user logging in
   
   This allows using the authenticating user's username and password to bind to the LDAP server.  This is desirable because it allows for looking up the yubikey attributes without needing to create a service account.

2. Add STARTTLS support
   
   This allows connecting to LDAP servers that only listen on port 389 but use STARTTLS to get a TLS connection

3. Add support for LDAP client certificate authentication
   
   This adds support for using a client cert/key to authenticate to an LDAP server.  It is separate from binding with a username and password and can either be used alongside it or with an anonymous bind to the server.  (This one actually closes #68)