### PR TITLE
Fix implicit declaration warning of mkostemp

### DIFF
--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -28,6 +28,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#define _GNU_SOURCE
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>


### PR DESCRIPTION
mkostemp() requires the _GNU_SOURCE feature test macro.
See man 3 mkostemp.