### PR TITLE
Add always_prompt configuration option to skip initial check for YubiKey

### DIFF
--- a/README
+++ b/README
@@ -171,6 +171,13 @@ stacked modules password and will never prompt the user - if no
 password is available or the password is not appropriate, the user
 will be denied access.
 
+always_prompt::
+If set, don't attempt to do a lookup to determine if the user has a
+YubiKey configured but instead prompt for one no matter what. This
+is useful in the case where ldap_bind_as_user is enabled but this
+module is being used to read the user's password (in a YubiKey+OTP
+auth scenario).
+
 nullok::
 If set, don't fail when there are no tokens declared for the user
 in the authorization mapping files or in LDAP.

--- a/pam_yubico.8.txt
+++ b/pam_yubico.8.txt
@@ -41,6 +41,9 @@ Before prompting the user for their password, the module first tries the previou
 *use_first_pass*::
 Forces the module to use a previous stacked modules password and will never prompt the user - if no password is available or the password is not appropriate, the user will be denied access.
 
+*always_prompt*::
+If set, don't attempt to do a lookup to determine if the user has a YubiKey configured but instead prompt for one no matter what. This is useful in the case where ldap_bind_as_user is enabled but this module is being used to read the user's password (in a YubiKey+OTP auth scenario).
+
 *nullok*::
 Don’t fail when there are no tokens declared for the user in the authorization mapping files or in LDAP. This can be used to make YubiKey authentication optional unless the user has associated tokens.
 


### PR DESCRIPTION
As raised in #174, ldap_bind_as_user cannot be used if this module is set to get YubiKey+OTP because the initial ldap lookup fails (since the password is not set yet).  `always_prompt` will stil the initial lookup, meaning that the user will be given the chance to enter their password.