### PR TITLE
If the challenge-response cannot be updated, show the correct error message

### DIFF
--- a/pam_yubico.c
+++ b/pam_yubico.c
@@ -678,6 +678,7 @@ do_challenge_response(pam_handle_t *pamh, struct cfg *cfg, const char *username)
   /*
    * Write the challenge and response we will expect the next time to the state file.
    */
+  errstr = "Error updating YubiKey challenge, please check syslog or contact your system administrator";
   if (response_len > sizeof(state.response)) {
     DBG("Got too long response ??? (%u/%zu)", response_len, sizeof(state.response));
     goto out;
@@ -723,7 +724,6 @@ do_challenge_response(pam_handle_t *pamh, struct cfg *cfg, const char *username)
     goto restpriv_out;
   }
 
-  errstr = "Error updating YubiKey challenge, please check syslog or contact your system administrator";
   if (! write_chalresp_state (f, &state))
     goto out;
   if (fclose(f) < 0) {


### PR DESCRIPTION
If the PAM module cannot update the challenge response file (due to permissions errors, usually), the incorrect error message is displayed "Error communicating with YubiKey...".

This is a small patch that makes it so the correct error message is sent to the PAM client, which makes resolving this issue a lot easier.

However a broader question might be: should authentication succeed if this fails?

Attached a simple PAM client test program
[pamtest.zip](https://github.com/Yubico/yubico-pam/files/2756801/pamtest.zip)

