### PR TITLE
Adds autotools option for building without documentation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -58,6 +58,7 @@ endif
 ykpamcfg_SOURCES = ykpamcfg.c
 ykpamcfg_LDADD = libpam_util.la
 
+if ENABLE_DOC
 if YKPERS
 dist_man1_MANS = ykpamcfg.1
 endif
@@ -77,6 +78,8 @@ SUFFIXES = .1.txt .1 .8.txt .8
 .8.txt.8:
 	$(A2X) -L --format=manpage -a revdate="Version $(VERSION)" $<
 
+
+endif
 
 if ENABLE_COV
 AM_CFLAGS += --coverage

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,14 @@ AC_CHECK_LIB([pam], [pam_start], [AC_SUBST([LIBPAM], ["-lpam"])])
 
 AC_SEARCH_LIBS([pam_modutil_drop_priv], ["pam"], [AC_DEFINE([HAVE_PAM_MODUTIL_DROP_PRIV], [1])])
 
+# --disable-documentation
+AC_ARG_ENABLE([documentation],
+	      [AS_HELP_STRING([--disable-documentation],
+			     [do not build documentation])],
+			     [enable_doc="${enableval}" ],
+			     [enable_doc="yes"])
+AM_CONDITIONAL(ENABLE_DOC, test "$enable_doc" != "no")
+
 AC_ARG_WITH([ldap],
             [AS_HELP_STRING([--without-ldap],
               [disable support for ldap])],


### PR DESCRIPTION
- removes a2x dependency used for man page generation by configuring with:
  ./configure --disable-documentation