### PR TITLE
Adding a static code analysis github workflow

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,32 @@
+name: static code analysis
+
+on: [push]
+env:
+  SCAN_IMG:
+    yes-docker-local.artifactory.in.yubico.org/static-code-analysis/c:v1
+  COMPILE_DEPS: "libykclient-dev libykpers-1-dev libyubikey-dev"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+
+    - name: Prep scan
+      run: |
+        docker login yes-docker-local.artifactory.in.yubico.org/ \
+             -u svc-static-code-analysis-reader \
+             -p ${{ secrets.ARTIFACTORY_READER_TOKEN }}
+        docker pull ${SCAN_IMG}
+
+    - name: Scan and fail if warnings
+      run: |
+        docker run -v${PWD}:/k -e COMPILE_DEPS="${COMPILE_DEPS}" \
+          -e PROJECT_NAME=${GITHUB_REPOSITORY#Yubico/} -t ${SCAN_IMG}
+
+    - uses: actions/upload-artifact@master
+      if: failure()
+      with:
+        name: suppression_files
+        path: suppression_files


### PR DESCRIPTION
This only runs on push for now so PRs are not covered. PRs are special in that if it comes from a fork it does not have access to the docker registry secrets in the repo but I have found no way of testing for the presence from within a github flow.

As of today the scanners show no warnings.