### PR TITLE
Fix typo in man pages

### DIFF
--- a/ykpamcfg.1.txt
+++ b/ykpamcfg.1.txt
@@ -8,7 +8,7 @@ YKPAMCFG(1)
 ykpamcfg - Manage user settings for the Yubico PAM module
 
 == SYNOPSIS
-*ykmapcfg* [-1 | -2] [-A] [-p] [-i] [-v] [-V] [-h]
+*ykpamcfg* [-1 | -2] [-A] [-p] [-i] [-v] [-V] [-h]
 
 == OPTIONS
 *-1*::


### PR DESCRIPTION
Exectuable is named `ykpamcfg` but man pages referred to it as `ykmapcfg`. Fixed that.