### PR TITLE
RFC4515 support added to %u in ldap search filter (#223)

### DIFF
--- a/tests/util_test.c
+++ b/tests/util_test.c
@@ -279,8 +279,29 @@ static void test_filter_printf(void) {
     printf("test_filter_printf OK\n");
 }
 
+static void test_rfc4515_replace(void) {
+    assert(rfc4515_length("", NULL) == 1);
+    assert(rfc4515_length(" ", NULL) == 2);
+    assert(rfc4515_length("test1234567890_.", NULL) == 17);
+    assert(rfc4515_length("\\test\\test\\", NULL) == 18);
+    assert(rfc4515_length("*test*test*", NULL) == 18);
+    assert(rfc4515_length("(test(test(", NULL) == 18);
+    assert(rfc4515_length(")test)test)", NULL) == 18);
+    assert(rfc4515_length("\\\\**(())", NULL) == 25);
+
+    assert(!strcmp(rfc4515_replace(""), ""));
+    assert(!strcmp(rfc4515_replace(" "), " "));
+    assert(!strcmp(rfc4515_replace("test1234567890_."), "test1234567890_."));
+    assert(!strcmp(rfc4515_replace("\\test\\test\\"), "\\5Ctest\\5Ctest\\5C"));
+    assert(!strcmp(rfc4515_replace("*test*test*"), "\\2Atest\\2Atest\\2A"));
+    assert(!strcmp(rfc4515_replace("(test(test("), "\\28test\\28test\\28"));
+    assert(!strcmp(rfc4515_replace(")test)test)"), "\\29test\\29test\\29"));
+    assert(!strcmp(rfc4515_replace("\\\\**(())"), "\\5C\\5C\\2A\\2A\\28\\28\\29\\29"));
+    printf("test_rfc4515_replace OK\n");
+}
 int main (void) {
   test_filter_printf();
+  test_rfc4515_replace();
   test_get_user_cfgfile_path();
   test_check_user_token();
 #if HAVE_CR

--- a/util.h
+++ b/util.h
@@ -103,4 +103,7 @@ int challenge_response(YK_KEY *yk, int slot,
 size_t filter_result_len(const char *filter, const char *user, char *output);
 char *filter_printf(const char *filter, const char *user);
 
+size_t rfc4515_length ( const char* in, char* out );
+char* rfc4515_replace ( const char* in );
+
 #endif /* __PAM_YUBICO_UTIL_H_INCLUDED__ */


### PR DESCRIPTION
This update implements RFC4515 for the username, which replaces `% u` in the LDAP search filter.
A detailed description can be found in issue #223. 