### PR TITLE
Better token parsing in authorized_yubikeys file (check_user_token)

### DIFF
--- a/util.c
+++ b/util.c
@@ -341,7 +341,10 @@ check_user_token (const char *authfile,
     {
       char *saveptr = NULL;
       if (buf[strlen (buf) - 1] == '\n')
+      {
+	s_user = NULL;
 	buf[strlen (buf) - 1] = '\0';
+      }
       if (buf[0] == '#') {
           /* This is a comment and we may skip it. */
           if(verbose)
@@ -364,9 +367,9 @@ check_user_token (const char *authfile,
 	  do
 	    {
 	      s_token = strtok_r (NULL, ":", &saveptr);
-
+	
         /* If the last token was less then 12 bytes */
-        if (strlen(s_token) < 12 && saveptr == NULL)
+        if (s_token != NULL && strlen(s_token) < 12 && saveptr == NULL)
         {
           /* move the file pointer back to the beggining of the token, so it can be read next time */
           fseek(opwfile, ftell(opwfile) - strlen(s_token), SEEK_SET);


### PR DESCRIPTION
There is a possible bug while having `/home/$USER/.yubico/authorized_yubikeys` file longer than 1024 bytes in a single line. I can see that the authorized_yubikeys file is parsed by buffering 1024 bytes. The code relies on the fact that the first token is always the username. But when the file is larger than 1024 bytes, the second time called fgets returns the rest of the yubikeys line, but the rest of the line does (and probably shouldn't) start with the username. So when the yubikey is not found in the first 1025 bytes, the auth will fail. To fix the username problem I have added a check if the username is undefined (NULL), so it won't change the username every time a part of the file is loaded.

The second problem is that when the 1024 buffer cuts the token in two parts. For this, I have added a check that if the last token length is less than 12, it will move back the file pointer for the token length, so it can be read as a whole in the next fgets.

We have found this possible bug when creating a uthorized_yubikeys with many tokens so the final file size is larger than 1024 bytes. We have been able to hotfix this by splitting the file by '\n' character after the last correctly read token.